### PR TITLE
Issue 30

### DIFF
--- a/examples/Profiling.hs
+++ b/examples/Profiling.hs
@@ -1,7 +1,7 @@
 module Main where
 
-import Data.Monoid        (mconcat)
-import System.Directory   (getCurrentDirectory)
+import Data.Monoid      (mconcat)
+import System.Directory (getCurrentDirectory)
 
 import qualified Data.ByteString   as BS
 import qualified Data.Ruby.Marshal as Marshal
@@ -9,5 +9,5 @@ import qualified Data.Ruby.Marshal as Marshal
 main :: IO ()
 main = do
   dir <- getCurrentDirectory
-  rbs <- BS.readFile (mconcat [dir, "/test/bin/bigArray.bin"])
-  putStrLn $ show (Marshal.load rbs)
+  rbs <- BS.readFile (mconcat [dir, "/test/bin/42.bin"])
+  putStrLn . show $ Marshal.load rbs

--- a/examples/Profiling.hs
+++ b/examples/Profiling.hs
@@ -1,13 +1,17 @@
+{-# LANGUAGE LambdaCase #-}
+
 module Main where
 
 import Data.Monoid      (mconcat)
 import System.Directory (getCurrentDirectory)
 
+import Data.Ruby.Marshal           as Marshal
 import qualified Data.ByteString   as BS
-import qualified Data.Ruby.Marshal as Marshal
 
 main :: IO ()
 main = do
   dir <- getCurrentDirectory
   rbs <- BS.readFile (mconcat [dir, "/test/bin/42.bin"])
-  putStrLn . show $ Marshal.load rbs
+  putStrLn . show $ Marshal.load rbs >>= \case
+    RFixnum x -> Just (x * x)
+    _         -> Nothing

--- a/examples/Profiling.hs
+++ b/examples/Profiling.hs
@@ -7,29 +7,20 @@ import System.Directory (getCurrentDirectory)
 
 import Data.Ruby.Marshal (load, RubyObject(..))
 import Data.Vector       (Vector)
-import Debug.Trace       (traceShow)
 
 import qualified Data.ByteString as BS
 import qualified Data.Foldable   as F
 
-debug :: Show a => a -> a
-debug x = traceShow x x
-
-loadBigArray :: IO (Maybe RubyObject)
-loadBigArray = do
-  dir <- getCurrentDirectory
-  rbs <- BS.readFile (mconcat [dir, "/test/bin/bigArray.bin"])
-  return $ load rbs
-
 sumFixnum :: Vector RubyObject -> Integer
-sumFixnum xs = F.foldr' (+) 0 $ (debug (fmap f xs))
+sumFixnum xs = F.foldl' (+) 0 $ fmap f xs
   where
     f :: RubyObject -> Integer
     f (RFixnum x) = toInteger x
 
 main :: IO ()
 main = do
-  array <- loadBigArray
-  print $ case array of
-    Just (RArray xs) -> Just $ sumFixnum xs
-    _                -> Nothing
+  dir <- getCurrentDirectory
+  rbs <- BS.readFile (mconcat [dir, "/test/bin/bigArray.bin"])
+  print $ load rbs >>= \case
+    RArray xs -> Just $ sumFixnum xs
+    _         -> Nothing

--- a/examples/Profiling.hs
+++ b/examples/Profiling.hs
@@ -10,11 +10,11 @@ import System.Directory  (getCurrentDirectory)
 import qualified Data.ByteString as BS
 import qualified Data.Foldable   as F
 
-sumFixnum :: Vector RubyObject -> Integer
+sumFixnum :: Vector RubyObject -> Int
 sumFixnum xs = F.foldl' (+) 0 $ fmap f xs
   where
-    f :: RubyObject -> Integer
-    f (RFixnum x) = toInteger x
+    f :: RubyObject -> Int
+    f (RFixnum x) = x
 
 main :: IO ()
 main = do

--- a/examples/Profiling.hs
+++ b/examples/Profiling.hs
@@ -14,7 +14,7 @@ import qualified Data.Foldable   as F
 loadBigArray :: IO (Maybe RubyObject)
 loadBigArray = do
   dir <- getCurrentDirectory
-  rbs <- BS.readFile (mconcat [dir, "/test/bin/loadBigArray.bin"])
+  rbs <- BS.readFile (mconcat [dir, "/test/bin/bigArray.bin"])
   return $ load rbs
 
 sumFixnum :: Vector RubyObject -> Integer

--- a/examples/Profiling.hs
+++ b/examples/Profiling.hs
@@ -21,6 +21,6 @@ main :: IO ()
 main = do
   dir <- getCurrentDirectory
   rbs <- BS.readFile (mconcat [dir, "/test/bin/bigArray.bin"])
-  putStrLn . show $ load rbs >>= \case
+  print $ load rbs >>= \case
     RArray xs -> Just $ sumFixnum xs
     _         -> Nothing

--- a/examples/Profiling.hs
+++ b/examples/Profiling.hs
@@ -7,9 +7,13 @@ import System.Directory (getCurrentDirectory)
 
 import Data.Ruby.Marshal (load, RubyObject(..))
 import Data.Vector       (Vector)
+import Debug.Trace       (traceShow)
 
 import qualified Data.ByteString as BS
 import qualified Data.Foldable   as F
+
+debug :: Show a => a -> a
+debug x = traceShow x x
 
 loadBigArray :: IO (Maybe RubyObject)
 loadBigArray = do
@@ -18,7 +22,7 @@ loadBigArray = do
   return $ load rbs
 
 sumFixnum :: Vector RubyObject -> Integer
-sumFixnum xs = F.foldr' (+) 0 $ fmap f xs
+sumFixnum xs = F.foldr' (+) 0 $ (debug (fmap f xs))
   where
     f :: RubyObject -> Integer
     f (RFixnum x) = toInteger x

--- a/examples/Profiling.hs
+++ b/examples/Profiling.hs
@@ -5,14 +5,14 @@ module Main where
 import Data.Monoid      (mconcat)
 import System.Directory (getCurrentDirectory)
 
-import Data.Foldable     (foldr')
 import Data.Ruby.Marshal (load, RubyObject(..))
 import Data.Vector       (Vector)
 
 import qualified Data.ByteString as BS
+import qualified Data.Foldable   as F
 
 sumFixnum :: Vector RubyObject -> Integer
-sumFixnum xs = foldr' (+) 0 $ fmap f xs
+sumFixnum xs = F.foldr' (+) 0 $ fmap f xs
   where
     f :: RubyObject -> Integer
     f (RFixnum x) = toInteger x

--- a/examples/Profiling.hs
+++ b/examples/Profiling.hs
@@ -2,11 +2,10 @@
 
 module Main where
 
-import Data.Monoid      (mconcat)
-import System.Directory (getCurrentDirectory)
-
+import Data.Monoid       (mconcat)
 import Data.Ruby.Marshal (load, RubyObject(..))
 import Data.Vector       (Vector)
+import System.Directory  (getCurrentDirectory)
 
 import qualified Data.ByteString as BS
 import qualified Data.Foldable   as F

--- a/examples/Profiling.hs
+++ b/examples/Profiling.hs
@@ -11,6 +11,12 @@ import Data.Vector       (Vector)
 import qualified Data.ByteString as BS
 import qualified Data.Foldable   as F
 
+loadBigArray :: IO (Maybe RubyObject)
+loadBigArray = do
+  dir <- getCurrentDirectory
+  rbs <- BS.readFile (mconcat [dir, "/test/bin/loadBigArray.bin"])
+  return $ load rbs
+
 sumFixnum :: Vector RubyObject -> Integer
 sumFixnum xs = F.foldr' (+) 0 $ fmap f xs
   where
@@ -19,8 +25,7 @@ sumFixnum xs = F.foldr' (+) 0 $ fmap f xs
 
 main :: IO ()
 main = do
-  dir <- getCurrentDirectory
-  rbs <- BS.readFile (mconcat [dir, "/test/bin/bigArray.bin"])
-  print $ load rbs >>= \case
-    RArray xs -> Just $ sumFixnum xs
-    _         -> Nothing
+  array <- loadBigArray
+  print $ case array of
+    Just (RArray xs) -> Just $ sumFixnum xs
+    _                -> Nothing

--- a/examples/Profiling.hs
+++ b/examples/Profiling.hs
@@ -5,14 +5,22 @@ module Main where
 import Data.Monoid      (mconcat)
 import System.Directory (getCurrentDirectory)
 
+import Data.Foldable     (foldr')
 import Data.Ruby.Marshal (load, RubyObject(..))
+import Data.Vector       (Vector)
 
 import qualified Data.ByteString as BS
+
+sumFixnum :: Vector RubyObject -> Integer
+sumFixnum xs = foldr' (+) 0 $ fmap f xs
+  where
+    f :: RubyObject -> Integer
+    f (RFixnum x) = toInteger x
 
 main :: IO ()
 main = do
   dir <- getCurrentDirectory
-  rbs <- BS.readFile (mconcat [dir, "/test/bin/42.bin"])
+  rbs <- BS.readFile (mconcat [dir, "/test/bin/bigArray.bin"])
   putStrLn . show $ load rbs >>= \case
-    RFixnum x -> Just (x * x)
+    RArray xs -> Just $ sumFixnum xs
     _         -> Nothing

--- a/examples/Profiling.hs
+++ b/examples/Profiling.hs
@@ -5,13 +5,14 @@ module Main where
 import Data.Monoid      (mconcat)
 import System.Directory (getCurrentDirectory)
 
-import Data.Ruby.Marshal           as Marshal
-import qualified Data.ByteString   as BS
+import Data.Ruby.Marshal (load, RubyObject(..))
+
+import qualified Data.ByteString as BS
 
 main :: IO ()
 main = do
   dir <- getCurrentDirectory
   rbs <- BS.readFile (mconcat [dir, "/test/bin/42.bin"])
-  putStrLn . show $ Marshal.load rbs >>= \case
+  putStrLn . show $ load rbs >>= \case
     RFixnum x -> Just (x * x)
     _         -> Nothing

--- a/ruby-marshal.cabal
+++ b/ruby-marshal.cabal
@@ -46,6 +46,7 @@ executable Profiling
     , bytestring    >= 0.9.0
     , directory     >= 1.2.1.0
     , ruby-marshal  -any
+    , vector      >= 0.10.0
   hs-source-dirs:
     examples
   main-is:

--- a/src/Data/Ruby/Marshal.hs
+++ b/src/Data/Ruby/Marshal.hs
@@ -31,6 +31,11 @@ import qualified Data.ByteString as BS
 -- built-in binary serialisation format.
 load :: BS.ByteString
      -- ^ Serialised Ruby object
-     -> Either String RubyObject
+     -> Maybe RubyObject
      -- ^ De-serialisation result
-load = decode
+load = fromEitherToMaybe . decode
+
+-- | Converts an Either to a Maybe.
+fromEitherToMaybe :: Either a b -> Maybe b
+fromEitherToMaybe (Left  _) = Nothing
+fromEitherToMaybe (Right x) = Just x

--- a/test/MarshalSpec.hs
+++ b/test/MarshalSpec.hs
@@ -8,7 +8,7 @@ import Test.Hspec
 import qualified Data.ByteString as BS
 import qualified Data.Vector     as V
 
-loadBin :: FilePath -> IO (Either String RubyObject)
+loadBin :: FilePath -> IO (Maybe RubyObject)
 loadBin path = do
     bs <- BS.readFile path
     return $ load bs
@@ -18,74 +18,74 @@ spec = describe "load" $ do
   context "when we have nil" $
     it "should parse" $ do
       object <- loadBin "test/bin/nil.bin"
-      object `shouldBe` Right RNil
+      object `shouldBe` Just RNil
 
   context "when we have true" $
     it "should parse" $ do
       object <- loadBin "test/bin/true.bin"
-      object `shouldBe` Right (RBool True)
+      object `shouldBe` Just (RBool True)
 
   context "when we have false" $
     it "should parse" $ do
       object <- loadBin "test/bin/false.bin"
-      object `shouldBe` Right (RBool False)
+      object `shouldBe` Just (RBool False)
 
   context "when we have 0" $
     it "should parse" $ do
       object <- loadBin "test/bin/0.bin"
-      object `shouldBe` Right (RFixnum 0)
+      object `shouldBe` Just (RFixnum 0)
 
   context "when we have -42" $
     it "should parse" $ do
       object <- loadBin "test/bin/neg42.bin"
-      object `shouldBe` Right (RFixnum (-42))
+      object `shouldBe` Just (RFixnum (-42))
 
   context "when we have 42" $
     it "should parse" $ do
       object <- loadBin "test/bin/42.bin"
-      object `shouldBe` Right (RFixnum 42)
+      object `shouldBe` Just (RFixnum 42)
 
   context "when we have -2048" $
     it "should parse" $ do
       object <- loadBin "test/bin/neg2048.bin"
-      object `shouldBe` Right (RFixnum (-2048))
+      object `shouldBe` Just (RFixnum (-2048))
 
   context "when we have 2048" $
     it "should parse" $ do
       object <- loadBin "test/bin/2048.bin"
-      object `shouldBe` Right (RFixnum 2048)
+      object `shouldBe` Just (RFixnum 2048)
 
   context "when we have [nil]" $
     it "should parse" $ do
       object <- loadBin "test/bin/nilArray.bin"
-      object `shouldBe` Right (RArray $ V.fromList [RNil])
+      object `shouldBe` Just (RArray $ V.fromList [RNil])
 
   context "when we have [true, false]" $
     it "should parse" $ do
       object <- loadBin "test/bin/boolArray.bin"
-      object `shouldBe` Right (RArray $ V.fromList [RBool True, RBool False])
+      object `shouldBe` Just (RArray $ V.fromList [RBool True, RBool False])
 
   context "when we have [-2048, -42, 0, 42, 2048]" $
     it "should parse" $ do
       object <- loadBin "test/bin/fixnumArray.bin"
-      object `shouldBe` Right (RArray $ V.fromList [RFixnum (-2048), RFixnum (-42), RFixnum 0, RFixnum 42, RFixnum 2048])
+      object `shouldBe` Just (RArray $ V.fromList [RFixnum (-2048), RFixnum (-42), RFixnum 0, RFixnum 42, RFixnum 2048])
 
   context "when we have ['hello', 'haskell']" $
     it "should parse" $ do
       object <- loadBin "test/bin/stringArray.bin"
-      object `shouldBe` Right (RArray $ V.fromList [RString "hello", RString "haskell"])
+      object `shouldBe` Just (RArray $ V.fromList [RString "hello", RString "haskell"])
 
   context "when we have { 0 => false, 1 => true }" $
     it "should parse" $ do
       object <- loadBin "test/bin/fixnumHash.bin"
-      object `shouldBe` Right (RHash $ V.fromList [(RFixnum 0, RBool False), (RFixnum 1, RBool True)])
+      object `shouldBe` Just (RHash $ V.fromList [(RFixnum 0, RBool False), (RFixnum 1, RBool True)])
 
   context "when we have 'hello haskell'" $
     it "should parse" $ do
       object <- loadBin "test/bin/rawString.bin"
-      object `shouldBe` Right (RString "hello haskell")
+      object `shouldBe` Just (RString "hello haskell")
 
   context "when we have 3.33333" $
     it "should parse" $ do
       object <- loadBin "test/bin/float.bin"
-      object `shouldBe` Right (RFloat 3.33333)
+      object `shouldBe` Just (RFloat 3.33333)


### PR DESCRIPTION
This PR replaces Either w/Maybe and adds an example to Profiling.hs that actually uses the library. 

The interface was changed because I feel that `load` should have a simple interface. If consumers of the library want more sophisticated examples then they should use the parser combinators to meet their own needs.

Writing a real example in Profiling.hs was an attempt to feel the pain of using the library. It feels too easy to write partial functions or to wrap everything in Maybe and this has made me consider re-investigating GADTs to see if they might alleviated this pain https://github.com/filib/ruby-marshal/issues/5.