### PR TITLE
Issue 46

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+- Separated modules by concern.
+- Hid underlying Get monad from consumers to allow us to change the parsing
+  library without breaking consumers should a more performant one become
+  available.
+- Added Rubyable type class to make it easier to go between RubyObject and plain
+  Haskell values.
+- Replaced Double with Float as per Marshal format.
+- Replaced internal representation of Hash with Vector of tuples to simplify
+  Rubyable type class and usage for consumers.
+- Added more type safety by extracting ADT of all possible Ruby string
+  encodings.
+- Re-ordered parser to try parsing simpler objects first.
+
+# 0.0.1
+
+- Completed fully-functioning parser for a subset of Ruby objects serialised
+  with Ruby's Marshal format.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 0.1.0
+
 - Separated modules by concern.
 - Hid underlying Get monad from consumers to allow us to change the parsing
   library without breaking consumers should a more performant one become

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Added more type safety by extracting ADT of all possible Ruby string
   encodings.
 - Re-ordered parser to try parsing simpler objects first.
+- Used strict State monad instead of non-strict.
 
 # 0.0.1
 

--- a/README.md
+++ b/README.md
@@ -30,26 +30,22 @@ create an issue or open a pull request using the guidelines below.
 
 module Main where
 
-import Data.Monoid       (mconcat)
-import Data.Ruby.Marshal (decode, RubyObject(..))
+import Data.Ruby.Marshal
 import System.Directory  (getCurrentDirectory)
 
 import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as DM
 
-key :: RubyObject
-key = RIVar (RString "user_id", "UTF-8")
-
-lookupId :: RubyObject -> Maybe RubyObject
-lookupId (RHash cookie) = DM.lookup key cookie
-lookupId _              = Nothing
+lookupUserID :: IVar -> RubyObject -> Maybe IVar
+lookupUserID key hash = fromRuby hash >>= \map' ->
+  DM.lookup key map'
 
 main :: IO ()
 main = do
   dir <- getCurrentDirectory
   rbs <- BS.readFile (mconcat [dir, "/test/bin/railsCookie.bin"])
   print $ case decode rbs of
-    Just cookie -> lookupId cookie
+    Just cookie -> lookupUserID ("user_id", UTF_8) cookie
     Nothing     -> Nothing
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as DM
 
 lookupUserID :: IVar -> RubyObject -> Maybe IVar
-lookupUserID key hash = fromRuby hash >>= \map' ->
-  DM.lookup key map'
+lookupUserID key hash = fromRuby hash >>= \cookie ->
+  DM.lookup key cookie
 
 main :: IO ()
 main = do

--- a/README.md
+++ b/README.md
@@ -31,12 +31,15 @@ create an issue or open a pull request using the guidelines below.
 module Main where
 
 import Data.Ruby.Marshal
-import System.Directory  (getCurrentDirectory)
+import Data.ByteString  (ByteString)
+import System.Directory (getCurrentDirectory)
 
 import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as DM
 
-lookupUserID :: IVar -> RubyObject -> Maybe IVar
+lookupUserID :: (ByteString, RubyStringEncoding)
+             -> RubyObject
+             -> Maybe (ByteString, RubyStringEncoding)
 lookupUserID key hash = fromRuby hash >>= \cookie ->
   DM.lookup key cookie
 

--- a/examples/RailsSession.hs
+++ b/examples/RailsSession.hs
@@ -8,7 +8,7 @@ import System.Directory  (getCurrentDirectory)
 import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as DM
 
-lookupUserID :: IVar -> RubyObject -> Maybe IVar
+lookupUserID :: (BS.ByteString, RubyStringEncoding) -> RubyObject -> Maybe (BS.ByteString, RubyStringEncoding)
 lookupUserID key hash = fromRuby hash >>= \cookie ->
   DM.lookup key cookie
 

--- a/examples/RailsSession.hs
+++ b/examples/RailsSession.hs
@@ -2,13 +2,11 @@
 
 module Main where
 
-import Data.Ruby.Marshal (decode, fromRuby, RubyObject(..), REncoding(..))
+import Data.Ruby.Marshal
 import System.Directory  (getCurrentDirectory)
 
 import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as DM
-
-type IVar = (BS.ByteString, REncoding)
 
 lookupUserID :: IVar -> RubyObject -> Maybe IVar
 lookupUserID key hash = fromRuby hash >>= \map' ->

--- a/examples/RailsSession.hs
+++ b/examples/RailsSession.hs
@@ -9,8 +9,8 @@ import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as DM
 
 lookupUserID :: IVar -> RubyObject -> Maybe IVar
-lookupUserID key hash = fromRuby hash >>= \map' ->
-  DM.lookup key map'
+lookupUserID key hash = fromRuby hash >>= \cookie ->
+  DM.lookup key cookie
 
 main :: IO ()
 main = do

--- a/examples/RailsSession.hs
+++ b/examples/RailsSession.hs
@@ -2,10 +2,8 @@
 
 module Main where
 
-import Data.Ruby.Marshal          (decode, RubyObject(..))
-import Data.Ruby.Marshal.Encoding (REncoding(..))
-import Data.Ruby.Marshal.Types    (fromRuby)
-import System.Directory           (getCurrentDirectory)
+import Data.Ruby.Marshal (decode, fromRuby, RubyObject(..), REncoding(..))
+import System.Directory (getCurrentDirectory)
 
 import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as DM

--- a/examples/RailsSession.hs
+++ b/examples/RailsSession.hs
@@ -3,14 +3,14 @@
 module Main where
 
 import Data.Ruby.Marshal (decode, fromRuby, RubyObject(..), REncoding(..))
-import System.Directory (getCurrentDirectory)
+import System.Directory  (getCurrentDirectory)
 
 import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as DM
 
-lookupUserID :: (BS.ByteString, REncoding)
-             -> RubyObject
-             -> Maybe (BS.ByteString, REncoding)
+type IVar = (BS.ByteString, REncoding)
+
+lookupUserID :: IVar -> RubyObject -> Maybe IVar
 lookupUserID key hash = fromRuby hash >>= \map' ->
   DM.lookup key map'
 

--- a/examples/RailsSession.hs
+++ b/examples/RailsSession.hs
@@ -2,24 +2,24 @@
 
 module Main where
 
-import Data.Monoid       (mconcat)
-import Data.Ruby.Marshal (decode, RubyObject(..))
-import System.Directory  (getCurrentDirectory)
+import Data.Ruby.Marshal          (decode, RubyObject(..))
+import Data.Ruby.Marshal.Encoding (REncoding(..))
+import Data.Ruby.Marshal.Types    (fromRuby)
+import System.Directory           (getCurrentDirectory)
 
 import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as DM
 
-key :: RubyObject
-key = RIVar (RString "user_id", "UTF-8")
-
-lookupId :: RubyObject -> Maybe RubyObject
-lookupId (RHash cookie) = DM.lookup key cookie
-lookupId _              = Nothing
+lookupUserID :: (BS.ByteString, REncoding)
+             -> RubyObject
+             -> Maybe (BS.ByteString, REncoding)
+lookupUserID key hash = fromRuby hash >>= \map' ->
+  DM.lookup key map'
 
 main :: IO ()
 main = do
   dir <- getCurrentDirectory
   rbs <- BS.readFile (mconcat [dir, "/test/bin/railsCookie.bin"])
   print $ case decode rbs of
-    Just cookie -> lookupId cookie
+    Just cookie -> lookupUserID ("user_id", UTF_8) cookie
     Nothing     -> Nothing

--- a/examples/RailsSession.hs
+++ b/examples/RailsSession.hs
@@ -3,12 +3,15 @@
 module Main where
 
 import Data.Ruby.Marshal
-import System.Directory  (getCurrentDirectory)
+import Data.ByteString  (ByteString)
+import System.Directory (getCurrentDirectory)
 
 import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as DM
 
-lookupUserID :: (BS.ByteString, RubyStringEncoding) -> RubyObject -> Maybe (BS.ByteString, RubyStringEncoding)
+lookupUserID :: (ByteString, RubyStringEncoding)
+             -> RubyObject
+             -> Maybe (ByteString, RubyStringEncoding)
 lookupUserID key hash = fromRuby hash >>= \cookie ->
   DM.lookup key cookie
 

--- a/ruby-marshal.cabal
+++ b/ruby-marshal.cabal
@@ -40,9 +40,9 @@ library
       Data.Ruby.Marshal
     , Data.Ruby.Marshal.Encoding
     , Data.Ruby.Marshal.Get
+    , Data.Ruby.Marshal.Int
     , Data.Ruby.Marshal.RubyObject
     , Data.Ruby.Marshal.Types
-    , Data.Ruby.Marshal.Internal.Int
 
 test-suite spec
   ghc-options:

--- a/ruby-marshal.cabal
+++ b/ruby-marshal.cabal
@@ -1,16 +1,31 @@
-name:          ruby-marshal
-version:       0.0.1
-synopsis:      Parse a subset of Ruby objects serialised with Marshal.dump.
-description:   Parse a subset of Ruby objects serialised with Marshal.dump.
-homepage:      https://github.com/filib/ruby-marshal
-license:       MIT
-license-file:  LICENSE
-author:        Philip Cunningham
-maintainer:    hello@filib.io
-category:      Data
-build-type:    Simple
-tested-with:   GHC == 7.8, GHC == 7.10
-cabal-version: >= 1.10
+name:
+  ruby-marshal
+version:
+  0.0.1
+synopsis:
+  Parse a subset of Ruby objects serialised with Marshal.dump.
+description:
+  Parse a subset of Ruby objects serialised with Marshal.dump.
+homepage:
+  https://github.com/filib/ruby-marshal
+license:
+  MIT
+license-file:
+  LICENSE
+author:
+  Philip Cunningham
+maintainer:
+  hello@filib.io
+category:
+  Data
+build-type:
+  Simple
+tested-with:
+  GHC == 7.8, GHC == 7.10
+cabal-version:
+  >= 1.10
+extra-source-files:
+  CHANGELOG.md
 
 Source-repository head
   type: git
@@ -27,13 +42,13 @@ library
   hs-source-dirs:
     src
   build-depends:
-      base        >= 4.7 && < 5
-    , cereal      >= 0.3.5.0 && < 0.5.0.0
-    , bytestring  >= 0.9.0
-    , containers  >= 0.5.0
-    , string-conv >= 0.1
-    , mtl         >= 2.2
-    , vector      >= 0.10.0
+      base        >= 4.7    && <= 5
+    , cereal      >= 0.4.0  && <= 0.5.0
+    , bytestring  >= 0.9.0  && <= 0.12.0
+    , containers  >= 0.5.0  && <= 0.6.0
+    , string-conv >= 0.1    && <= 0.2
+    , mtl         >= 2.2.0  && <= 2.3.0
+    , vector      >= 0.10.0 && <= 0.11.0
   default-language:
     Haskell2010
   exposed-modules:
@@ -51,14 +66,15 @@ test-suite spec
   hs-source-dirs:
     src, test
   build-depends:
-      base        >= 4.7 && < 5
-    , cereal      >= 0.3.5.0 && < 0.5.0.0
-    , bytestring  >= 0.9.0
-    , containers  >= 0.5.0.0
+      ruby-marshal -any
+    , base
+    , bytestring
+    , cereal
+    , containers
     , hspec
-    , mtl         >= 2.2
-    , string-conv >= 0.1
-    , vector      >= 0.10.0
+    , mtl
+    , string-conv
+    , vector
   default-language:
     Haskell2010
   other-modules:

--- a/ruby-marshal.cabal
+++ b/ruby-marshal.cabal
@@ -38,6 +38,7 @@ library
     Haskell2010
   exposed-modules:
       Data.Ruby.Marshal
+    , Data.Ruby.Marshal.Encoding
     , Data.Ruby.Marshal.Get
     , Data.Ruby.Marshal.Types
     , Data.Ruby.Marshal.Internal.Int

--- a/ruby-marshal.cabal
+++ b/ruby-marshal.cabal
@@ -1,7 +1,7 @@
 name:
   ruby-marshal
 version:
-  0.0.1
+  0.1.0
 synopsis:
   Parse a subset of Ruby objects serialised with Marshal.dump.
 description:

--- a/ruby-marshal.cabal
+++ b/ruby-marshal.cabal
@@ -41,6 +41,7 @@ library
     , Data.Ruby.Marshal.Encoding
     , Data.Ruby.Marshal.Get
     , Data.Ruby.Marshal.Int
+    , Data.Ruby.Marshal.Monad
     , Data.Ruby.Marshal.RubyObject
     , Data.Ruby.Marshal.Types
 

--- a/ruby-marshal.cabal
+++ b/ruby-marshal.cabal
@@ -40,6 +40,7 @@ library
       Data.Ruby.Marshal
     , Data.Ruby.Marshal.Encoding
     , Data.Ruby.Marshal.Get
+    , Data.Ruby.Marshal.RubyObject
     , Data.Ruby.Marshal.Types
     , Data.Ruby.Marshal.Internal.Int
 

--- a/src/Data/Ruby/Marshal.hs
+++ b/src/Data/Ruby/Marshal.hs
@@ -8,7 +8,7 @@
 -- Stability :  experimental
 -- Portability: portable
 --
--- Simple interface to deserialise Ruby Marshal binary.
+-- Simple interface to parse Ruby Marshal binary.
 --
 --------------------------------------------------------------------
 
@@ -33,7 +33,7 @@ import Data.Serialize             (runGet)
 
 import qualified Data.ByteString as BS
 
--- | Deserialises a subset of Ruby objects serialised with Marshal, Ruby's
+-- | Parses a subset of Ruby objects serialised with Marshal, Ruby's
 -- built-in binary serialisation format.
 decode :: BS.ByteString
        -- ^ Serialised Ruby object
@@ -41,7 +41,7 @@ decode :: BS.ByteString
        -- ^ De-serialisation result
 decode = hush . decodeEither
 
--- | Deserialises a subset of Ruby objects serialised with Marshal, Ruby's
+-- | Parses a subset of Ruby objects serialised with Marshal, Ruby's
 -- built-in binary serialisation format.
 decodeEither :: BS.ByteString
              -- ^ Serialised Ruby object

--- a/src/Data/Ruby/Marshal.hs
+++ b/src/Data/Ruby/Marshal.hs
@@ -27,9 +27,9 @@ import Data.Ruby.Marshal.Get
 import Data.Ruby.Marshal.RubyObject
 import Data.Ruby.Marshal.Types
 
-import Control.Monad.State     (evalStateT)
-import Data.Ruby.Marshal.Monad (emptyCache, runMarshal)
-import Data.Serialize          (runGet)
+import Control.Monad.State.Strict (evalStateT)
+import Data.Ruby.Marshal.Monad    (emptyCache, runMarshal)
+import Data.Serialize             (runGet)
 
 import qualified Data.ByteString as BS
 

--- a/src/Data/Ruby/Marshal.hs
+++ b/src/Data/Ruby/Marshal.hs
@@ -13,7 +13,7 @@
 --------------------------------------------------------------------
 
 module Data.Ruby.Marshal (
-  -- * Simple interface to deserialise Ruby Marshal binary
+  -- * Decoding
     decode
   , decodeEither
   -- * Re-exported modules

--- a/src/Data/Ruby/Marshal.hs
+++ b/src/Data/Ruby/Marshal.hs
@@ -24,11 +24,11 @@ module Data.Ruby.Marshal (
 import Data.Ruby.Marshal.Get
 import Data.Ruby.Marshal.Types
 
-import Control.Monad.State (evalStateT)
-import Data.Serialize      (runGet)
+import Control.Monad.State     (evalStateT)
+import Data.Ruby.Marshal.Monad (emptyCache, runMarshal)
+import Data.Serialize          (runGet)
 
 import qualified Data.ByteString as BS
-import qualified Data.Vector     as V
 
 -- | Deserialises a subset of Ruby objects serialised with Marshal, Ruby's
 -- built-in binary serialisation format.
@@ -45,10 +45,6 @@ decodeEither :: BS.ByteString
              -> Either String RubyObject
              -- ^ Error message or de-serialisation result
 decodeEither = runGet (evalStateT (runMarshal getRubyObject) emptyCache)
-
--- | Constructs an empty cache to store symbols and objects.
-emptyCache :: Cache
-emptyCache = Cache { _symbols = V.empty, _objects = V.empty }
 
 -- | Converts an Either to a Maybe.
 hush :: Either a b -> Maybe b

--- a/src/Data/Ruby/Marshal.hs
+++ b/src/Data/Ruby/Marshal.hs
@@ -17,7 +17,6 @@ module Data.Ruby.Marshal (
     decode
   , decodeEither
   -- * Re-exported modules
-  , module Data.Ruby.Marshal.Get
   , module Data.Ruby.Marshal.Types
 ) where
 

--- a/src/Data/Ruby/Marshal.hs
+++ b/src/Data/Ruby/Marshal.hs
@@ -22,7 +22,7 @@ module Data.Ruby.Marshal (
 ) where
 
 import Data.Ruby.Marshal.Get
-import Data.Ruby.Marshal.Types (Cache(..), RubyObject(..), Marshal(..))
+import Data.Ruby.Marshal.Types
 
 import Control.Monad.State (evalStateT)
 import Data.Serialize      (runGet)

--- a/src/Data/Ruby/Marshal.hs
+++ b/src/Data/Ruby/Marshal.hs
@@ -16,11 +16,15 @@ module Data.Ruby.Marshal (
   -- * Decoding
     decode
   , decodeEither
+  -- * Lifting into and lowering from RubyObject
+  , fromRuby
+  , toRuby
   -- * Re-exported modules
   , module Data.Ruby.Marshal.Types
 ) where
 
 import Data.Ruby.Marshal.Get
+import Data.Ruby.Marshal.RubyObject
 import Data.Ruby.Marshal.Types
 
 import Control.Monad.State     (evalStateT)

--- a/src/Data/Ruby/Marshal/Encoding.hs
+++ b/src/Data/Ruby/Marshal/Encoding.hs
@@ -15,16 +15,16 @@
 --------------------------------------------------------------------
 
 module Data.Ruby.Marshal.Encoding (
-    -- * The @REncoding@ type
+    -- * The @RubyStringEncoding@ type
     fromEnc
   , toEnc
-  , REncoding(..)
+  , RubyStringEncoding(..)
 ) where
 
 import qualified Data.ByteString as BS
 
 -- | ADT representing all supported Ruby encodings.
-data REncoding = ASCII_8BIT
+data RubyStringEncoding = ASCII_8BIT
                | Big5
                | Big5_HKSCS
                | Big5_UAO
@@ -128,7 +128,7 @@ data REncoding = ASCII_8BIT
                deriving (Eq, Ord, Show)
 
 -- | Lifts encoding strings into encoding ADT.
-toEnc :: BS.ByteString -> REncoding
+toEnc :: BS.ByteString -> RubyStringEncoding
 toEnc "ASCII-8BIT"                 = ASCII_8BIT
 toEnc "UTF-8"                      = UTF_8
 toEnc "US-ASCII"                   = US_ASCII
@@ -232,7 +232,7 @@ toEnc "SJIS-SoftBank"              = SJIS_SoftBank
 toEnc _                            = UnsupportedEncoding
 
 -- | Lowers encoding ADT into an encoding string.
-fromEnc :: REncoding -> BS.ByteString
+fromEnc :: RubyStringEncoding -> BS.ByteString
 fromEnc ASCII_8BIT                 = "ASCII-8BIT"
 fromEnc UTF_8                      = "UTF-8"
 fromEnc US_ASCII                   = "US-ASCII"

--- a/src/Data/Ruby/Marshal/Encoding.hs
+++ b/src/Data/Ruby/Marshal/Encoding.hs
@@ -123,7 +123,7 @@ data REncoding = ASCII_8BIT
                | Windows_31J
                | Windows_874
                | InvalidEncoding
-               deriving (Eq, Show)
+               deriving (Eq, Ord, Show)
 
 toEnc :: BS.ByteString -> REncoding
 toEnc "ASCII-8BIT"                 = ASCII_8BIT

--- a/src/Data/Ruby/Marshal/Encoding.hs
+++ b/src/Data/Ruby/Marshal/Encoding.hs
@@ -23,6 +23,7 @@ module Data.Ruby.Marshal.Encoding (
 
 import qualified Data.ByteString as BS
 
+-- | ADT representing all supported Ruby encodings.
 data REncoding = ASCII_8BIT
                | Big5
                | Big5_HKSCS
@@ -126,6 +127,7 @@ data REncoding = ASCII_8BIT
                | InvalidEncoding
                deriving (Eq, Ord, Show)
 
+-- | Lifts encoding strings into encoding ADT.
 toEnc :: BS.ByteString -> REncoding
 toEnc "ASCII-8BIT"                 = ASCII_8BIT
 toEnc "UTF-8"                      = UTF_8
@@ -229,6 +231,7 @@ toEnc "UTF8-SoftBank"              = UTF8_SoftBank
 toEnc "SJIS-SoftBank"              = SJIS_SoftBank
 toEnc _                            = InvalidEncoding
 
+-- | Lowers encoding ADT into an encoding string.
 fromEnc :: REncoding -> BS.ByteString
 fromEnc ASCII_8BIT                 = "ASCII-8BIT"
 fromEnc UTF_8                      = "UTF-8"

--- a/src/Data/Ruby/Marshal/Encoding.hs
+++ b/src/Data/Ruby/Marshal/Encoding.hs
@@ -124,7 +124,7 @@ data REncoding = ASCII_8BIT
                | Windows_1258
                | Windows_31J
                | Windows_874
-               | InvalidEncoding
+               | UnsupportedEncoding
                deriving (Eq, Ord, Show)
 
 -- | Lifts encoding strings into encoding ADT.
@@ -229,7 +229,7 @@ toEnc "ISO-2022-JP-KDDI"           = ISO_2022_JP_KDDI
 toEnc "stateless-ISO-2022-JP-KDDI" = Stateless_ISO_2022_JP_KDDI
 toEnc "UTF8-SoftBank"              = UTF8_SoftBank
 toEnc "SJIS-SoftBank"              = SJIS_SoftBank
-toEnc _                            = InvalidEncoding
+toEnc _                            = UnsupportedEncoding
 
 -- | Lowers encoding ADT into an encoding string.
 fromEnc :: REncoding -> BS.ByteString
@@ -333,4 +333,4 @@ fromEnc ISO_2022_JP_KDDI           = "ISO-2022-JP-KDDI"
 fromEnc Stateless_ISO_2022_JP_KDDI = "stateless-ISO-2022-JP-KDDI"
 fromEnc UTF8_SoftBank              = "UTF8-SoftBank"
 fromEnc SJIS_SoftBank              = "SJIS-SoftBank"
-fromEnc _                          = "InvalidEncoding"
+fromEnc _                          = "UnsupportedEncoding"

--- a/src/Data/Ruby/Marshal/Encoding.hs
+++ b/src/Data/Ruby/Marshal/Encoding.hs
@@ -15,6 +15,7 @@
 --------------------------------------------------------------------
 
 module Data.Ruby.Marshal.Encoding (
+    -- * The @REncoding@ type
     fromEnc
   , toEnc
   , REncoding(..)

--- a/src/Data/Ruby/Marshal/Encoding.hs
+++ b/src/Data/Ruby/Marshal/Encoding.hs
@@ -1,0 +1,332 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+--------------------------------------------------------------------
+-- |
+-- Module    : Data.Ruby.Marshal.Encoding
+-- Copyright : (c) Philip Cunningham, 2015
+-- License   : MIT
+--
+-- Maintainer:  hello@filib.io
+-- Stability :  experimental
+-- Portability: portable
+--
+-- Encoding types.
+--
+--------------------------------------------------------------------
+
+module Data.Ruby.Marshal.Encoding (
+    fromEnc
+  , toEnc
+  , REncoding(..)
+) where
+
+import qualified Data.ByteString as BS
+
+data REncoding = ASCII_8BIT
+               | Big5
+               | Big5_HKSCS
+               | Big5_UAO
+               | CP50220
+               | CP50221
+               | CP51932
+               | CP850
+               | CP852
+               | CP855
+               | CP949
+               | CP950
+               | CP951
+               | EUC_JP
+               | EUC_JP_2004
+               | EUC_KR
+               | EUC_TW
+               | Emacs_Mule
+               | EucJP_ms
+               | GB12345
+               | GB18030
+               | GB1988
+               | GB2312
+               | GBK
+               | IBM437
+               | IBM737
+               | IBM775
+               | IBM852
+               | IBM855
+               | IBM857
+               | IBM860
+               | IBM861
+               | IBM862
+               | IBM863
+               | IBM864
+               | IBM865
+               | IBM866
+               | IBM869
+               | ISO_2022_JP
+               | ISO_2022_JP_2
+               | ISO_2022_JP_KDDI
+               | ISO_8859_1
+               | ISO_8859_10
+               | ISO_8859_11
+               | ISO_8859_13
+               | ISO_8859_14
+               | ISO_8859_15
+               | ISO_8859_16
+               | ISO_8859_2
+               | ISO_8859_3
+               | ISO_8859_4
+               | ISO_8859_5
+               | ISO_8859_6
+               | ISO_8859_7
+               | ISO_8859_8
+               | ISO_8859_9
+               | KOI8_R
+               | KOI8_U
+               | MacCentEuro
+               | MacCroatian
+               | MacCyrillic
+               | MacGreek
+               | MacIceland
+               | MacJapanese
+               | MacRoman
+               | MacRomania
+               | MacThai
+               | MacTurkish
+               | MacUkraine
+               | SJIS_DoCoMo
+               | SJIS_KDDI
+               | SJIS_SoftBank
+               | Shift_JIS
+               | Stateless_ISO_2022_JP
+               | Stateless_ISO_2022_JP_KDDI
+               | TIS_620
+               | US_ASCII
+               | UTF8_DoCoMo
+               | UTF8_KDDI
+               | UTF8_MAC
+               | UTF8_SoftBank
+               | UTF_16
+               | UTF_16BE
+               | UTF_16LE
+               | UTF_32
+               | UTF_32BE
+               | UTF_32LE
+               | UTF_7
+               | UTF_8
+               | Windows_1250
+               | Windows_1251
+               | Windows_1252
+               | Windows_1253
+               | Windows_1254
+               | Windows_1255
+               | Windows_1256
+               | Windows_1257
+               | Windows_1258
+               | Windows_31J
+               | Windows_874
+               | InvalidEncoding
+               deriving (Eq, Show)
+
+toEnc :: BS.ByteString -> REncoding
+toEnc "ASCII-8BIT"                 = ASCII_8BIT
+toEnc "UTF-8"                      = UTF_8
+toEnc "US-ASCII"                   = US_ASCII
+toEnc "Big5"                       = Big5
+toEnc "Big5-HKSCS"                 = Big5_HKSCS
+toEnc "Big5-UAO"                   = Big5_UAO
+toEnc "CP949"                      = CP949
+toEnc "Emacs-Mule"                 = Emacs_Mule
+toEnc "EUC-JP"                     = EUC_JP
+toEnc "EUC-KR"                     = EUC_KR
+toEnc "EUC-TW"                     = EUC_TW
+toEnc "GB18030"                    = GB18030
+toEnc "GBK"                        = GBK
+toEnc "ISO-8859-1"                 = ISO_8859_1
+toEnc "ISO-8859-2"                 = ISO_8859_2
+toEnc "ISO-8859-3"                 = ISO_8859_3
+toEnc "ISO-8859-4"                 = ISO_8859_4
+toEnc "ISO-8859-5"                 = ISO_8859_5
+toEnc "ISO-8859-6"                 = ISO_8859_6
+toEnc "ISO-8859-7"                 = ISO_8859_7
+toEnc "ISO-8859-8"                 = ISO_8859_8
+toEnc "ISO-8859-9"                 = ISO_8859_9
+toEnc "ISO-8859-10"                = ISO_8859_10
+toEnc "ISO-8859-11"                = ISO_8859_11
+toEnc "ISO-8859-13"                = ISO_8859_13
+toEnc "ISO-8859-14"                = ISO_8859_14
+toEnc "ISO-8859-15"                = ISO_8859_15
+toEnc "ISO-8859-16"                = ISO_8859_16
+toEnc "KOI8-R"                     = KOI8_R
+toEnc "KOI8-U"                     = KOI8_U
+toEnc "Shift_JIS"                  = Shift_JIS
+toEnc "UTF-16BE"                   = UTF_16BE
+toEnc "UTF-16LE"                   = UTF_16LE
+toEnc "UTF-32BE"                   = UTF_32BE
+toEnc "UTF-32LE"                   = UTF_32LE
+toEnc "Windows-31J"                = Windows_31J
+toEnc "Windows-1251"               = Windows_1251
+toEnc "IBM437"                     = IBM437
+toEnc "IBM737"                     = IBM737
+toEnc "IBM775"                     = IBM775
+toEnc "CP850"                      = CP850
+toEnc "IBM852"                     = IBM852
+toEnc "CP852"                      = CP852
+toEnc "IBM855"                     = IBM855
+toEnc "CP855"                      = CP855
+toEnc "IBM857"                     = IBM857
+toEnc "IBM860"                     = IBM860
+toEnc "IBM861"                     = IBM861
+toEnc "IBM862"                     = IBM862
+toEnc "IBM863"                     = IBM863
+toEnc "IBM864"                     = IBM864
+toEnc "IBM865"                     = IBM865
+toEnc "IBM866"                     = IBM866
+toEnc "IBM869"                     = IBM869
+toEnc "Windows-1258"               = Windows_1258
+toEnc "GB1988"                     = GB1988
+toEnc "macCentEuro"                = MacCentEuro
+toEnc "macCroatian"                = MacCroatian
+toEnc "macCyrillic"                = MacCyrillic
+toEnc "macGreek"                   = MacGreek
+toEnc "macIceland"                 = MacIceland
+toEnc "macRoman"                   = MacRoman
+toEnc "macRomania"                 = MacRomania
+toEnc "macThai"                    = MacThai
+toEnc "macTurkish"                 = MacTurkish
+toEnc "macUkraine"                 = MacUkraine
+toEnc "CP950"                      = CP950
+toEnc "CP951"                      = CP951
+toEnc "stateless-ISO-2022-JP"      = Stateless_ISO_2022_JP
+toEnc "eucJP-ms"                   = EucJP_ms
+toEnc "CP51932"                    = CP51932
+toEnc "EUC-JP-2004"                = EUC_JP_2004
+toEnc "GB2312"                     = GB2312
+toEnc "GB12345"                    = GB12345
+toEnc "ISO-2022-JP"                = ISO_2022_JP
+toEnc "ISO-2022-JP-2"              = ISO_2022_JP_2
+toEnc "CP50220"                    = CP50220
+toEnc "CP50221"                    = CP50221
+toEnc "Windows-1252"               = Windows_1252
+toEnc "Windows-1250"               = Windows_1250
+toEnc "Windows-1256"               = Windows_1256
+toEnc "Windows-1253"               = Windows_1253
+toEnc "Windows-1255"               = Windows_1255
+toEnc "Windows-1254"               = Windows_1254
+toEnc "TIS-620"                    = TIS_620
+toEnc "Windows-874"                = Windows_874
+toEnc "Windows-1257"               = Windows_1257
+toEnc "MacJapanese"                = MacJapanese
+toEnc "UTF-7"                      = UTF_7
+toEnc "UTF8-MAC"                   = UTF8_MAC
+toEnc "UTF-16"                     = UTF_16
+toEnc "UTF-32"                     = UTF_32
+toEnc "UTF8-DoCoMo"                = UTF8_DoCoMo
+toEnc "SJIS-DoCoMo"                = SJIS_DoCoMo
+toEnc "UTF8-KDDI"                  = UTF8_KDDI
+toEnc "SJIS-KDDI"                  = SJIS_KDDI
+toEnc "ISO-2022-JP-KDDI"           = ISO_2022_JP_KDDI
+toEnc "stateless-ISO-2022-JP-KDDI" = Stateless_ISO_2022_JP_KDDI
+toEnc "UTF8-SoftBank"              = UTF8_SoftBank
+toEnc "SJIS-SoftBank"              = SJIS_SoftBank
+toEnc _                            = InvalidEncoding
+
+fromEnc :: REncoding -> BS.ByteString
+fromEnc ASCII_8BIT                 = "ASCII-8BIT"
+fromEnc UTF_8                      = "UTF-8"
+fromEnc US_ASCII                   = "US-ASCII"
+fromEnc Big5                       = "Big5"
+fromEnc Big5_HKSCS                 = "Big5-HKSCS"
+fromEnc Big5_UAO                   = "Big5-UAO"
+fromEnc CP949                      = "CP949"
+fromEnc Emacs_Mule                 = "Emacs-Mule"
+fromEnc EUC_JP                     = "EUC-JP"
+fromEnc EUC_KR                     = "EUC-KR"
+fromEnc EUC_TW                     = "EUC-TW"
+fromEnc GB18030                    = "GB18030"
+fromEnc GBK                        = "GBK"
+fromEnc ISO_8859_1                 = "ISO-8859-1"
+fromEnc ISO_8859_2                 = "ISO-8859-2"
+fromEnc ISO_8859_3                 = "ISO-8859-3"
+fromEnc ISO_8859_4                 = "ISO-8859-4"
+fromEnc ISO_8859_5                 = "ISO-8859-5"
+fromEnc ISO_8859_6                 = "ISO-8859-6"
+fromEnc ISO_8859_7                 = "ISO-8859-7"
+fromEnc ISO_8859_8                 = "ISO-8859-8"
+fromEnc ISO_8859_9                 = "ISO-8859-9"
+fromEnc ISO_8859_10                = "ISO-8859-10"
+fromEnc ISO_8859_11                = "ISO-8859-11"
+fromEnc ISO_8859_13                = "ISO-8859-13"
+fromEnc ISO_8859_14                = "ISO-8859-14"
+fromEnc ISO_8859_15                = "ISO-8859-15"
+fromEnc ISO_8859_16                = "ISO-8859-16"
+fromEnc KOI8_R                     = "KOI8-R"
+fromEnc KOI8_U                     = "KOI8-U"
+fromEnc Shift_JIS                  = "Shift_JIS"
+fromEnc UTF_16BE                   = "UTF-16BE"
+fromEnc UTF_16LE                   = "UTF-16LE"
+fromEnc UTF_32BE                   = "UTF-32BE"
+fromEnc UTF_32LE                   = "UTF-32LE"
+fromEnc Windows_31J                = "Windows-31J"
+fromEnc Windows_1251               = "Windows-1251"
+fromEnc IBM437                     = "IBM437"
+fromEnc IBM737                     = "IBM737"
+fromEnc IBM775                     = "IBM775"
+fromEnc CP850                      = "CP850"
+fromEnc IBM852                     = "IBM852"
+fromEnc CP852                      = "CP852"
+fromEnc IBM855                     = "IBM855"
+fromEnc CP855                      = "CP855"
+fromEnc IBM857                     = "IBM857"
+fromEnc IBM860                     = "IBM860"
+fromEnc IBM861                     = "IBM861"
+fromEnc IBM862                     = "IBM862"
+fromEnc IBM863                     = "IBM863"
+fromEnc IBM864                     = "IBM864"
+fromEnc IBM865                     = "IBM865"
+fromEnc IBM866                     = "IBM866"
+fromEnc IBM869                     = "IBM869"
+fromEnc Windows_1258               = "Windows-1258"
+fromEnc GB1988                     = "GB1988"
+fromEnc MacCentEuro                = "macCentEuro"
+fromEnc MacCroatian                = "macCroatian"
+fromEnc MacCyrillic                = "macCyrillic"
+fromEnc MacGreek                   = "macGreek"
+fromEnc MacIceland                 = "macIceland"
+fromEnc MacRoman                   = "macRoman"
+fromEnc MacRomania                 = "macRomania"
+fromEnc MacThai                    = "macThai"
+fromEnc MacTurkish                 = "macTurkish"
+fromEnc MacUkraine                 = "macUkraine"
+fromEnc CP950                      = "CP950"
+fromEnc CP951                      = "CP951"
+fromEnc Stateless_ISO_2022_JP      = "stateless-ISO-2022-JP"
+fromEnc EucJP_ms                   = "eucJP-ms"
+fromEnc CP51932                    = "CP51932"
+fromEnc EUC_JP_2004                = "EUC-JP-2004"
+fromEnc GB2312                     = "GB2312"
+fromEnc GB12345                    = "GB12345"
+fromEnc ISO_2022_JP                = "ISO-2022-JP"
+fromEnc ISO_2022_JP_2              = "ISO-2022-JP-2"
+fromEnc CP50220                    = "CP50220"
+fromEnc CP50221                    = "CP50221"
+fromEnc Windows_1252               = "Windows-1252"
+fromEnc Windows_1250               = "Windows-1250"
+fromEnc Windows_1256               = "Windows-1256"
+fromEnc Windows_1253               = "Windows-1253"
+fromEnc Windows_1255               = "Windows-1255"
+fromEnc Windows_1254               = "Windows-1254"
+fromEnc TIS_620                    = "TIS-620"
+fromEnc Windows_874                = "Windows-874"
+fromEnc Windows_1257               = "Windows-1257"
+fromEnc MacJapanese                = "MacJapanese"
+fromEnc UTF_7                      = "UTF-7"
+fromEnc UTF8_MAC                   = "UTF8-MAC"
+fromEnc UTF_16                     = "UTF-16"
+fromEnc UTF_32                     = "UTF-32"
+fromEnc UTF8_DoCoMo                = "UTF8-DoCoMo"
+fromEnc SJIS_DoCoMo                = "SJIS-DoCoMo"
+fromEnc UTF8_KDDI                  = "UTF8-KDDI"
+fromEnc SJIS_KDDI                  = "SJIS-KDDI"
+fromEnc ISO_2022_JP_KDDI           = "ISO-2022-JP-KDDI"
+fromEnc Stateless_ISO_2022_JP_KDDI = "stateless-ISO-2022-JP-KDDI"
+fromEnc UTF8_SoftBank              = "UTF8-SoftBank"
+fromEnc SJIS_SoftBank              = "SJIS-SoftBank"
+fromEnc _                          = "InvalidEncoding"

--- a/src/Data/Ruby/Marshal/Encoding.hs
+++ b/src/Data/Ruby/Marshal/Encoding.hs
@@ -10,7 +10,7 @@
 -- Stability :  experimental
 -- Portability: portable
 --
--- Encoding types.
+-- Ruby encoding types.
 --
 --------------------------------------------------------------------
 

--- a/src/Data/Ruby/Marshal/Get.hs
+++ b/src/Data/Ruby/Marshal/Get.hs
@@ -18,6 +18,7 @@
 --------------------------------------------------------------------
 
 module Data.Ruby.Marshal.Get (
+    -- * Ruby Marshal parsers
     getMarshalVersion
   , getRubyObject
 ) where

--- a/src/Data/Ruby/Marshal/Get.hs
+++ b/src/Data/Ruby/Marshal/Get.hs
@@ -114,7 +114,7 @@ getHash k v = marshalLabel "Hash" $ do
   V.replicateM n (liftM2 (,) k v)
 
 -- | Deserialises <http://docs.ruby-lang.org/en/2.1.0/marshal_rdoc.html#label-Instance+Variables Instance Variables>.
-getIVar :: Marshal RubyObject -> Marshal (RubyObject, REncoding)
+getIVar :: Marshal RubyObject -> Marshal (RubyObject, RubyStringEncoding)
 getIVar g = marshalLabel "IVar" $ do
   str <- g
   len <- getFixnum
@@ -137,7 +137,7 @@ getIVar g = marshalLabel "IVar" $ do
       return result
 
 -- | Pulls an Instance Variable out of the object cache.
-getObjectLink :: Marshal (RubyObject, REncoding)
+getObjectLink :: Marshal (RubyObject, RubyStringEncoding)
 getObjectLink = marshalLabel "ObjectLink" $ do
   index <- getFixnum
   maybeObject <- readObject index

--- a/src/Data/Ruby/Marshal/Get.hs
+++ b/src/Data/Ruby/Marshal/Get.hs
@@ -20,24 +20,13 @@
 module Data.Ruby.Marshal.Get (
     getMarshalVersion
   , getRubyObject
-  , getNil
-  , getBool
-  , getArray
-  , getFixnum
-  , getFloat
-  , getHash
-  , getIVar
-  , getObjectLink
-  , getString
-  , getSymbol
-  , getSymlink
 ) where
 
 import Control.Applicative
 import Data.Ruby.Marshal.Internal.Int
 import Data.Ruby.Marshal.Types
 
-import Control.Monad              (guard, liftM2)
+import Control.Monad              (liftM2)
 import Control.Monad.State        (get, gets, put)
 import Data.Ruby.Marshal.Encoding (toEnc)
 import Data.Serialize.Get         (Get, getBytes, getTwoOf, label)
@@ -79,16 +68,6 @@ getRubyObject = getMarshalVersion >> go
 
 --------------------------------------------------------------------
 -- Ancillary functions.
-
--- | Deserialises <http://ruby-doc.org/core-2.2.0/NilClass.html nil>.
-getNil :: Marshal ()
-getNil = marshalLabel "Nil" $ tag 48
-
--- | Deserialises <http://ruby-doc.org/core-2.2.0/TrueClass.html true> and
--- <http://ruby-doc.org/core-2.2.0/FalseClass.html false>.
-getBool :: Marshal Bool
-getBool = marshalLabel "Bool" $
-  True <$ tag 84 <|> False <$ tag 70
 
 -- | Deserialises <http://ruby-doc.org/core-2.2.0/Array.html Array>.
 getArray :: Marshal a -> Marshal (V.Vector a)
@@ -197,11 +176,6 @@ getSymlink = do
 -- | Lift label into Marshal monad.
 marshalLabel :: String -> Get a -> Marshal a
 marshalLabel x y = liftMarshal $ label x y
-
--- | Guard against invalid input.
-tag :: Word8 -> Get ()
-tag t = label "Tag" $
-  getWord8 >>= \b -> guard $ t == b
 
 -- | Look up object in our object cache.
 readObject :: Int -> Marshal (Maybe RubyObject)

--- a/src/Data/Ruby/Marshal/Get.hs
+++ b/src/Data/Ruby/Marshal/Get.hs
@@ -44,8 +44,8 @@ import qualified Data.Vector     as V
 -- | Deserialises Marshal version.
 getMarshalVersion :: Marshal (Word8, Word8)
 getMarshalVersion = liftAndLabel "Marshal Version" $
-  getTwoOf getWord8 getWord8 >>= \case
-    (4, 8) -> return (4, 8)
+  getTwoOf getWord8 getWord8 >>= \version -> case version of
+    (4, 8) -> return version
     _      -> fail "marshal version unsupported"
 
 -- | Deserialises a subset of Ruby objects.

--- a/src/Data/Ruby/Marshal/Get.hs
+++ b/src/Data/Ruby/Marshal/Get.hs
@@ -13,7 +13,7 @@
 -- Stability :  experimental
 -- Portability: portable
 --
--- Ruby Marshal deserialiser using @Data.Serialize@.
+-- Parsers for Ruby Marshal format.
 --
 --------------------------------------------------------------------
 

--- a/src/Data/Ruby/Marshal/Get.hs
+++ b/src/Data/Ruby/Marshal/Get.hs
@@ -57,15 +57,15 @@ getRubyObject = getMarshalVersion >> go
       NilChar        -> return RNil
       TrueChar       -> return $ RBool True
       FalseChar      -> return $ RBool False
-      ArrayChar      -> RArray  <$> getArray go
       FixnumChar     -> RFixnum <$> getFixnum
       FloatChar      -> RFloat  <$> getFloat
-      HashChar       -> RHash   <$> getHash go go
-      IVarChar       -> RIVar   <$> getIVar go
-      ObjectLinkChar -> RIVar   <$> getObjectLink
       StringChar     -> RString <$> getString
       SymbolChar     -> RSymbol <$> getSymbol
+      ObjectLinkChar -> RIVar   <$> getObjectLink
       SymlinkChar    -> RSymbol <$> getSymlink
+      ArrayChar      -> RArray  <$> getArray go
+      HashChar       -> RHash   <$> getHash go go
+      IVarChar       -> RIVar   <$> getIVar go
       _              -> return Unsupported
 
 --------------------------------------------------------------------

--- a/src/Data/Ruby/Marshal/Get.hs
+++ b/src/Data/Ruby/Marshal/Get.hs
@@ -75,7 +75,7 @@ getRubyObject = getMarshalVersion >> go
       StringC     -> RString <$> getString
       SymbolC     -> RSymbol <$> getSymbol
       SymlinkC    -> RSymbol <$> getSymlink
-      _           -> return $ RError Unsupported
+      _           -> return $ Unsupported
 
 --------------------------------------------------------------------
 -- Ancillary functions.

--- a/src/Data/Ruby/Marshal/Get.hs
+++ b/src/Data/Ruby/Marshal/Get.hs
@@ -63,7 +63,7 @@ getRubyObject = getMarshalVersion >> go
       StringChar     -> RString <$> getString
       SymbolChar     -> RSymbol <$> getSymbol
       SymlinkChar    -> RSymbol <$> getSymlink
-      _              -> return $ Unsupported
+      _              -> return Unsupported
 
 --------------------------------------------------------------------
 -- Ancillary functions.

--- a/src/Data/Ruby/Marshal/Get.hs
+++ b/src/Data/Ruby/Marshal/Get.hs
@@ -124,16 +124,15 @@ getIVar g = do
        denote <- g
        case symbol of
          RSymbol "E" -> case denote of
-           RBool True  -> cacheAndReturn str UTF_8
-           RBool False -> cacheAndReturn str US_ASCII
+           RBool True  -> return' (str, UTF_8)
+           RBool False -> return' (str, US_ASCII)
            _           -> fail "getIVar: expected bool"
          RSymbol "encoding" -> case denote of
-           RString enc -> cacheAndReturn str (toEnc enc)
+           RString enc -> return' (str, (toEnc enc))
            _           -> fail "getIVar: expected string"
          _          -> fail "getIVar: invalid ivar"
   where
-    cacheAndReturn string enc = do
-      let result = (string, enc)
+    return' result = do
       writeCache $ RIVar result
       marshalLabel "IVar" $ return result
 

--- a/src/Data/Ruby/Marshal/Get.hs
+++ b/src/Data/Ruby/Marshal/Get.hs
@@ -104,7 +104,7 @@ getFloat = marshalLabel "Float" $ do
   s <- getString
   x <- case readMaybe . toS $ s of
     Just float -> return float
-    Nothing    -> fail "getFloat: expected float"
+    Nothing    -> fail "expected float"
   return x
 
 -- | Deserialises <http://ruby-doc.org/core-2.2.0/Hash.html Hash>.
@@ -119,7 +119,7 @@ getIVar :: Marshal RubyObject -> Marshal (RubyObject, REncoding)
 getIVar g = marshalLabel "IVar" $ do
   str <- g
   len <- getFixnum
-  if | len /= 1 -> fail "getIvar: expected single character"
+  if | len /= 1 -> fail "expected single character"
      | otherwise   -> do
        symbol <- g
        denote <- g
@@ -127,11 +127,11 @@ getIVar g = marshalLabel "IVar" $ do
          RSymbol "E" -> case denote of
            RBool True  -> return' (str, UTF_8)
            RBool False -> return' (str, US_ASCII)
-           _           -> fail "getIVar: expected bool"
+           _           -> fail "expected bool"
          RSymbol "encoding" -> case denote of
            RString enc -> return' (str, (toEnc enc))
-           _           -> fail "getIVar: expected string"
-         _          -> fail "getIVar: invalid ivar"
+           _           -> fail "expected string"
+         _          -> fail "invalid ivar"
   where
     return' result = do
       writeCache $ RIVar result
@@ -144,7 +144,7 @@ getObjectLink = marshalLabel "ObjectLink" $ do
   maybeObject <- readObject index
   case maybeObject of
     Just (RIVar x) -> return x
-    _              -> fail "getObjectLink"
+    _              -> fail "invalid object link"
 
 -- | Deserialises <http://ruby-doc.org/core-2.2.0/String.html String>.
 getString :: Marshal BS.ByteString

--- a/src/Data/Ruby/Marshal/Get.hs
+++ b/src/Data/Ruby/Marshal/Get.hs
@@ -29,6 +29,7 @@ import Data.Ruby.Marshal.Types
 import Control.Monad              (liftM2)
 import Control.Monad.State        (get, gets, put)
 import Data.Ruby.Marshal.Encoding (toEnc)
+import Data.Ruby.Marshal.Monad    (_objects, _symbols, liftMarshal)
 import Data.Serialize.Get         (Get, getBytes, getTwoOf, label)
 import Data.String.Conv           (toS)
 import Text.Read                  (readMaybe)
@@ -52,19 +53,19 @@ getRubyObject = getMarshalVersion >> go
   where
     go :: Marshal RubyObject
     go = liftMarshal getWord8 >>= \case
-      NilC        -> return RNil
-      TrueC       -> return $ RBool True
-      FalseC      -> return $ RBool False
-      ArrayC      -> RArray  <$> getArray go
-      FixnumC     -> RFixnum <$> getFixnum
-      FloatC      -> RFloat  <$> getFloat
-      HashC       -> RHash   <$> getHash go go
-      IVarC       -> RIVar   <$> getIVar go
-      ObjectLinkC -> RIVar   <$> getObjectLink
-      StringC     -> RString <$> getString
-      SymbolC     -> RSymbol <$> getSymbol
-      SymlinkC    -> RSymbol <$> getSymlink
-      _           -> return $ Unsupported
+      NilChar        -> return RNil
+      TrueChar       -> return $ RBool True
+      FalseChar      -> return $ RBool False
+      ArrayChar      -> RArray  <$> getArray go
+      FixnumChar     -> RFixnum <$> getFixnum
+      FloatChar      -> RFloat  <$> getFloat
+      HashChar       -> RHash   <$> getHash go go
+      IVarChar       -> RIVar   <$> getIVar go
+      ObjectLinkChar -> RIVar   <$> getObjectLink
+      StringChar     -> RString <$> getString
+      SymbolChar     -> RSymbol <$> getSymbol
+      SymlinkChar    -> RSymbol <$> getSymlink
+      _              -> return $ Unsupported
 
 --------------------------------------------------------------------
 -- Ancillary functions.

--- a/src/Data/Ruby/Marshal/Get.hs
+++ b/src/Data/Ruby/Marshal/Get.hs
@@ -23,8 +23,9 @@ module Data.Ruby.Marshal.Get (
 ) where
 
 import Control.Applicative
-import Data.Ruby.Marshal.Internal.Int
+import Data.Ruby.Marshal.Int
 import Data.Ruby.Marshal.Types
+import Prelude
 
 import Control.Monad              (liftM2)
 import Data.Ruby.Marshal.Encoding (toEnc)
@@ -35,8 +36,6 @@ import Text.Read                  (readMaybe)
 
 import qualified Data.ByteString as BS
 import qualified Data.Vector     as V
-
-import Prelude hiding (length)
 
 --------------------------------------------------------------------
 -- Top-level functions.

--- a/src/Data/Ruby/Marshal/Get.hs
+++ b/src/Data/Ruby/Marshal/Get.hs
@@ -119,12 +119,12 @@ getFixnum = marshalLabel "Fixnum" $ do
       if x >= 0 && x <= 127 then return (x - 256) else return x
 
 -- | Deserialises <http://ruby-doc.org/core-2.2.0/Float.html Float>.
-getFloat :: Marshal Double
+getFloat :: Marshal Float
 getFloat = do
   s <- getString
   x <- case readMaybe . toS $ s of
     Just float -> return float
-    Nothing    -> fail "getFloat"
+    Nothing    -> fail "getFloat: expected float"
   marshalLabel "Float" $ return x
 
 -- | Deserialises <http://ruby-doc.org/core-2.2.0/Hash.html Hash>.

--- a/src/Data/Ruby/Marshal/Get.hs
+++ b/src/Data/Ruby/Marshal/Get.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE RankNTypes #-}
 
 --------------------------------------------------------------------
 -- |
@@ -38,14 +37,13 @@ import Control.Applicative
 import Data.Ruby.Marshal.Internal.Int
 import Data.Ruby.Marshal.Types
 
-import Control.Monad       (guard, liftM2, replicateM)
+import Control.Monad       (guard, liftM2)
 import Control.Monad.State (get, gets, put)
 import Data.Serialize.Get  (Get, getBytes, getTwoOf, label)
 import Data.String.Conv    (toS)
 import Text.Read           (readMaybe)
 
 import qualified Data.ByteString as BS
-import qualified Data.Map.Strict as DM
 import qualified Data.Vector     as V
 
 import Prelude hiding (length)
@@ -130,10 +128,10 @@ getFloat = do
   marshalLabel "Float" $ return x
 
 -- | Deserialises <http://ruby-doc.org/core-2.2.0/Hash.html Hash>.
-getHash :: forall k v. Ord k => Marshal k -> Marshal v -> Marshal (DM.Map k v)
+getHash :: Marshal a -> Marshal b -> Marshal (V.Vector (a, b))
 getHash k v = do
   n <- getFixnum
-  x <- DM.fromList `fmap` replicateM n (liftM2 (,) k v)
+  x <- V.replicateM n (liftM2 (,) k v)
   marshalLabel "Hash" $ return x
 
 -- | Deserialises <http://docs.ruby-lang.org/en/2.1.0/marshal_rdoc.html#label-Instance+Variables Instance Variables>.

--- a/src/Data/Ruby/Marshal/Get.hs
+++ b/src/Data/Ruby/Marshal/Get.hs
@@ -34,15 +34,15 @@ module Data.Ruby.Marshal.Get (
 ) where
 
 import Control.Applicative
-import Data.Ruby.Marshal.Encoding
 import Data.Ruby.Marshal.Internal.Int
 import Data.Ruby.Marshal.Types
 
-import Control.Monad       (guard, liftM2)
-import Control.Monad.State (get, gets, put)
-import Data.Serialize.Get  (Get, getBytes, getTwoOf, label)
-import Data.String.Conv    (toS)
-import Text.Read           (readMaybe)
+import Control.Monad              (guard, liftM2)
+import Control.Monad.State        (get, gets, put)
+import Data.Ruby.Marshal.Encoding (toEnc)
+import Data.Serialize.Get         (Get, getBytes, getTwoOf, label)
+import Data.String.Conv           (toS)
+import Text.Read                  (readMaybe)
 
 import qualified Data.ByteString as BS
 import qualified Data.Vector     as V

--- a/src/Data/Ruby/Marshal/Get.hs
+++ b/src/Data/Ruby/Marshal/Get.hs
@@ -75,8 +75,7 @@ getRubyObject = getMarshalVersion >> go
 getArray :: Marshal a -> Marshal (V.Vector a)
 getArray g = marshalLabel "Fixnum" $ do
   n <- getFixnum
-  x <- V.replicateM n g
-  return x
+  V.replicateM n g
 
 -- | Deserialises <http://ruby-doc.org/core-2.2.0/Fixnum.html Fixnum>.
 getFixnum :: Marshal Int
@@ -104,17 +103,15 @@ getFixnum = liftAndLabel "Fixnum" $ do
 getFloat :: Marshal Float
 getFloat = marshalLabel "Float" $ do
   s <- getString
-  x <- case readMaybe . toS $ s of
+  case readMaybe . toS $ s of
     Just float -> return float
     Nothing    -> fail "expected float"
-  return x
 
 -- | Deserialises <http://ruby-doc.org/core-2.2.0/Hash.html Hash>.
 getHash :: Marshal a -> Marshal b -> Marshal (V.Vector (a, b))
 getHash k v = marshalLabel "Hash" $ do
   n <- getFixnum
-  x <- V.replicateM n (liftM2 (,) k v)
-  return x
+  V.replicateM n (liftM2 (,) k v)
 
 -- | Deserialises <http://docs.ruby-lang.org/en/2.1.0/marshal_rdoc.html#label-Instance+Variables Instance Variables>.
 getIVar :: Marshal RubyObject -> Marshal (RubyObject, REncoding)
@@ -131,7 +128,7 @@ getIVar g = marshalLabel "IVar" $ do
            RBool False -> return' (str, US_ASCII)
            _           -> fail "expected bool"
          RSymbol "encoding" -> case denote of
-           RString enc -> return' (str, (toEnc enc))
+           RString enc -> return' (str, toEnc enc)
            _           -> fail "expected string"
          _          -> fail "invalid ivar"
   where
@@ -152,8 +149,7 @@ getObjectLink = marshalLabel "ObjectLink" $ do
 getString :: Marshal BS.ByteString
 getString = marshalLabel "RawString" $ do
   n <- getFixnum
-  x <- liftMarshal $ getBytes n
-  return x
+  liftMarshal $ getBytes n
 
 -- | Deserialises <http://ruby-doc.org/core-2.2.0/Symbol.html Symbol>.
 getSymbol :: Marshal BS.ByteString

--- a/src/Data/Ruby/Marshal/Int.hs
+++ b/src/Data/Ruby/Marshal/Int.hs
@@ -1,6 +1,6 @@
 --------------------------------------------------------------------
 -- |
--- Module    : Data.Ruby.Marshal.Internal.Int
+-- Module    : Data.Ruby.Marshal.Int
 -- Copyright : (c) Philip Cunningham, 2015
 -- License   : MIT
 --
@@ -12,7 +12,7 @@
 --
 --------------------------------------------------------------------
 
-module Data.Ruby.Marshal.Internal.Int (
+module Data.Ruby.Marshal.Int (
   -- * Signed integrals
     getInt8
   , getInt16le

--- a/src/Data/Ruby/Marshal/Int.hs
+++ b/src/Data/Ruby/Marshal/Int.hs
@@ -8,7 +8,7 @@
 -- Stability :  experimental
 -- Portability: portable
 --
--- Helper module for parsing Int.
+-- Parsers for signed and unsigned integrals.
 --
 --------------------------------------------------------------------
 

--- a/src/Data/Ruby/Marshal/Monad.hs
+++ b/src/Data/Ruby/Marshal/Monad.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module Data.Ruby.Marshal.Monad where
+
+import Control.Monad.State          (lift, MonadState, StateT)
+import Data.Ruby.Marshal.RubyObject (RubyObject)
+import Data.Serialize.Get           (Get)
+
+import qualified Data.Vector as V
+
+-- | State that we must carry around during parsing.
+data Cache = Cache {
+    _objects :: !(V.Vector RubyObject)
+    -- ^ object cache.
+  , _symbols :: !(V.Vector RubyObject)
+    -- ^ symbol cache.
+} deriving Show
+
+-- | Constructs an empty cache to store symbols and objects.
+emptyCache :: Cache
+emptyCache = Cache { _symbols = V.empty, _objects = V.empty }
+
+-- | Marshal monad endows the underlying Get monad with State.
+newtype Marshal a = Marshal {
+  runMarshal :: StateT Cache Get a
+} deriving (Functor, Applicative, Monad, MonadState Cache)
+
+-- | Lift Get monad into Marshal monad.
+liftMarshal :: Get a -> Marshal a
+liftMarshal = Marshal . lift

--- a/src/Data/Ruby/Marshal/Monad.hs
+++ b/src/Data/Ruby/Marshal/Monad.hs
@@ -1,10 +1,25 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
+--------------------------------------------------------------------
+-- |
+-- Module    : Data.Ruby.Marshal.Monad
+-- Copyright : (c) Philip Cunningham, 2015
+-- License   : MIT
+--
+-- Maintainer:  hello@filib.io
+-- Stability :  experimental
+-- Portability: portable
+--
+-- Marshal monad provides an object cache over the Get monad.
+--
+--------------------------------------------------------------------
+
 module Data.Ruby.Marshal.Monad where
 
 import Control.Monad.State          (get, gets, lift, put, MonadState, StateT)
 import Data.Ruby.Marshal.RubyObject (RubyObject(..))
 import Data.Serialize.Get           (Get)
+import Data.Vector                  (Vector)
 
 import qualified Data.Vector as V
 
@@ -17,11 +32,11 @@ newtype Marshal a = Marshal {
 liftMarshal :: Get a -> Marshal a
 liftMarshal = Marshal . lift
 
--- | State that we must carry around during parsing.
+-- | State that we must carry around during deserialisation.
 data Cache = Cache {
-    objects :: !(V.Vector RubyObject)
+    objects :: !(Vector RubyObject)
     -- ^ object cache.
-  , symbols :: !(V.Vector RubyObject)
+  , symbols :: !(Vector RubyObject)
     -- ^ symbol cache.
 } deriving Show
 
@@ -30,7 +45,7 @@ emptyCache :: Cache
 emptyCache = Cache { symbols = V.empty, objects = V.empty }
 
 -- | Look up value in cache.
-readCache :: Int -> (Cache -> V.Vector RubyObject) -> Marshal (Maybe RubyObject)
+readCache :: Int -> (Cache -> Vector RubyObject) -> Marshal (Maybe RubyObject)
 readCache index f = gets f >>= \cache -> return $ cache V.!? index
 
 -- | Look up object in object cache.

--- a/src/Data/Ruby/Marshal/Monad.hs
+++ b/src/Data/Ruby/Marshal/Monad.hs
@@ -29,15 +29,17 @@ data Cache = Cache {
 emptyCache :: Cache
 emptyCache = Cache { symbols = V.empty, objects = V.empty }
 
--- | Look up object in our object cache.
-readObject :: Int -> Marshal (Maybe RubyObject)
-readObject index = gets objects >>= \objectCache ->
-  return $ objectCache V.!? index
+-- | Look up value in cache.
+readCache :: Int -> (Cache -> V.Vector RubyObject) -> Marshal (Maybe RubyObject)
+readCache index f = gets f >>= \cache -> return $ cache V.!? index
 
--- | Look up a symbol in our symbol cache.
+-- | Look up object in object cache.
+readObject :: Int -> Marshal (Maybe RubyObject)
+readObject index = readCache index objects
+
+-- | Look up a symbol in symbol cache.
 readSymbol :: Int -> Marshal (Maybe RubyObject)
-readSymbol index = gets symbols >>= \symbolCache ->
-  return $ symbolCache V.!? index
+readSymbol index = readCache index symbols
 
 -- | Write an object to the appropriate cache.
 writeCache :: RubyObject -> Marshal ()

--- a/src/Data/Ruby/Marshal/Monad.hs
+++ b/src/Data/Ruby/Marshal/Monad.hs
@@ -16,6 +16,9 @@
 
 module Data.Ruby.Marshal.Monad where
 
+import Control.Applicative
+import Prelude
+
 import Control.Monad.State          (get, gets, lift, put, MonadState, StateT)
 import Data.Ruby.Marshal.RubyObject (RubyObject(..))
 import Data.Serialize.Get           (Get)

--- a/src/Data/Ruby/Marshal/Monad.hs
+++ b/src/Data/Ruby/Marshal/Monad.hs
@@ -19,7 +19,7 @@ module Data.Ruby.Marshal.Monad where
 import Control.Applicative
 import Prelude
 
-import Control.Monad.State          (get, gets, lift, put, MonadState, StateT)
+import Control.Monad.State.Strict   (get, gets, lift, put, MonadState, StateT)
 import Data.Ruby.Marshal.RubyObject (RubyObject(..))
 import Data.Serialize.Get           (Get)
 import Data.Vector                  (Vector)

--- a/src/Data/Ruby/Marshal/Monad.hs
+++ b/src/Data/Ruby/Marshal/Monad.hs
@@ -2,23 +2,11 @@
 
 module Data.Ruby.Marshal.Monad where
 
-import Control.Monad.State          (lift, MonadState, StateT)
-import Data.Ruby.Marshal.RubyObject (RubyObject)
+import Control.Monad.State          (get, gets, lift, put, MonadState, StateT)
+import Data.Ruby.Marshal.RubyObject (RubyObject(..))
 import Data.Serialize.Get           (Get)
 
 import qualified Data.Vector as V
-
--- | State that we must carry around during parsing.
-data Cache = Cache {
-    _objects :: !(V.Vector RubyObject)
-    -- ^ object cache.
-  , _symbols :: !(V.Vector RubyObject)
-    -- ^ symbol cache.
-} deriving Show
-
--- | Constructs an empty cache to store symbols and objects.
-emptyCache :: Cache
-emptyCache = Cache { _symbols = V.empty, _objects = V.empty }
 
 -- | Marshal monad endows the underlying Get monad with State.
 newtype Marshal a = Marshal {
@@ -28,3 +16,34 @@ newtype Marshal a = Marshal {
 -- | Lift Get monad into Marshal monad.
 liftMarshal :: Get a -> Marshal a
 liftMarshal = Marshal . lift
+
+-- | State that we must carry around during parsing.
+data Cache = Cache {
+    objects :: !(V.Vector RubyObject)
+    -- ^ object cache.
+  , symbols :: !(V.Vector RubyObject)
+    -- ^ symbol cache.
+} deriving Show
+
+-- | Constructs an empty cache to store symbols and objects.
+emptyCache :: Cache
+emptyCache = Cache { symbols = V.empty, objects = V.empty }
+
+-- | Look up object in our object cache.
+readObject :: Int -> Marshal (Maybe RubyObject)
+readObject index = gets objects >>= \objectCache ->
+  return $ objectCache V.!? index
+
+-- | Look up a symbol in our symbol cache.
+readSymbol :: Int -> Marshal (Maybe RubyObject)
+readSymbol index = gets symbols >>= \symbolCache ->
+  return $ symbolCache V.!? index
+
+-- | Write an object to the appropriate cache.
+writeCache :: RubyObject -> Marshal ()
+writeCache object = do
+  cache <- get
+  case object of
+    RIVar   _ -> put $ cache { objects = V.snoc (objects cache) object }
+    RSymbol _ -> put $ cache { symbols = V.snoc (symbols cache) object }
+    _         -> return ()

--- a/src/Data/Ruby/Marshal/RubyObject.hs
+++ b/src/Data/Ruby/Marshal/RubyObject.hs
@@ -17,15 +17,15 @@
 --------------------------------------------------------------------
 
 module Data.Ruby.Marshal.RubyObject (
-    module Data.Ruby.Marshal.Encoding
-  , module Data.Ruby.Marshal.RubyObject
+    REncoding(..)
+  , RubyObject(..)
 ) where
 
 import Control.Applicative
-import Data.Ruby.Marshal.Encoding
 import Prelude
 
-import Control.Arrow ((***))
+import Control.Arrow              ((***))
+import Data.Ruby.Marshal.Encoding (REncoding(..))
 
 import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as DM
@@ -51,18 +51,12 @@ data RubyObject
     -- ^ represents a @Float@
   | RSymbol                !BS.ByteString
     -- ^ represents a @Symbol@
-  | RError                 !Error
+  | Unsupported
     -- ^ represents an invalid object
   deriving (Eq, Ord, Show)
 
 -- | Handy type alias for IVars.
 type IVar = (BS.ByteString, REncoding)
-
--- | Convey when unsupported object encountered.
-data Error
-  = Unsupported
-    -- ^ represents an unsupported Ruby object
-  deriving (Eq, Ord, Show)
 
 -- | Transform plain Haskell values to RubyObjects and back.
 class Ruby a where

--- a/src/Data/Ruby/Marshal/RubyObject.hs
+++ b/src/Data/Ruby/Marshal/RubyObject.hs
@@ -17,7 +17,8 @@
 --------------------------------------------------------------------
 
 module Data.Ruby.Marshal.RubyObject (
-    REncoding(..)
+    IVar
+  , REncoding(..)
   , RubyObject(..)
 ) where
 

--- a/src/Data/Ruby/Marshal/RubyObject.hs
+++ b/src/Data/Ruby/Marshal/RubyObject.hs
@@ -16,9 +16,14 @@
 --
 --------------------------------------------------------------------
 
-module Data.Ruby.Marshal.RubyObject where
+module Data.Ruby.Marshal.RubyObject (
+    module Data.Ruby.Marshal.Encoding
+  , module Data.Ruby.Marshal.RubyObject
+) where
 
+import Control.Applicative
 import Data.Ruby.Marshal.Encoding
+import Prelude
 
 import Control.Arrow ((***))
 

--- a/src/Data/Ruby/Marshal/RubyObject.hs
+++ b/src/Data/Ruby/Marshal/RubyObject.hs
@@ -1,0 +1,145 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE IncoherentInstances #-}
+{-# LANGUAGE LambdaCase #-}
+
+--------------------------------------------------------------------
+-- |
+-- Module    : Data.Ruby.Marshal.RubyObject
+-- Copyright : (c) Philip Cunningham, 2015
+-- License   : MIT
+--
+-- Maintainer:  hello@filib.io
+-- Stability :  experimental
+-- Portability: portable
+--
+-- Core RubyObject data representation.
+--
+--------------------------------------------------------------------
+
+module Data.Ruby.Marshal.RubyObject where
+
+import Data.Ruby.Marshal.Encoding
+
+import Control.Arrow ((***))
+
+import qualified Data.ByteString as BS
+import qualified Data.Map.Strict as DM
+import qualified Data.Vector     as V
+
+-- | Representation of a Ruby object.
+data RubyObject
+  = RNil
+    -- ^ represents @nil@
+  | RBool                  !Bool
+    -- ^ represents @true@ or @false@
+  | RFixnum {-# UNPACK #-} !Int
+    -- ^ represents a @Fixnum@
+  | RArray                 !(V.Vector RubyObject)
+    -- ^ represents an @Array@
+  | RHash                  !(V.Vector (RubyObject, RubyObject))
+    -- ^ represents an @Hash@
+  | RIVar                  !(RubyObject, REncoding)
+    -- ^ represents an @IVar@
+  | RString                !BS.ByteString
+    -- ^ represents a @String@
+  | RFloat {-# UNPACK #-}  !Float
+    -- ^ represents a @Float@
+  | RSymbol                !BS.ByteString
+    -- ^ represents a @Symbol@
+  | RError                 !Error
+    -- ^ represents an invalid object
+  deriving (Eq, Ord, Show)
+
+-- | Convey when unsupported object encountered.
+data Error
+  = Unsupported
+    -- ^ represents an unsupported Ruby object
+  deriving (Eq, Ord, Show)
+
+-- | Transform plain Haskell values to RubyObjects and back.
+class Rubyable a where
+  -- | Takes a plain Haskell value and lifts into RubyObject
+  toRuby :: a -> RubyObject
+  -- | Takes a RubyObject transforms it into a more general Haskell value.
+  fromRuby :: RubyObject -> Maybe a
+
+-- core instances
+
+instance Rubyable RubyObject where
+  toRuby = id
+  fromRuby = Just
+
+instance Rubyable () where
+  toRuby _ = RNil
+  fromRuby = \case
+    RNil -> Just ()
+    _    -> Nothing
+
+instance Rubyable Bool where
+  toRuby = RBool
+  fromRuby = \case
+    RBool x -> Just x
+    _       -> Nothing
+
+instance Rubyable Int where
+  toRuby = RFixnum
+  fromRuby = \case
+    RFixnum x -> Just x
+    _         -> Nothing
+
+instance Rubyable a => Rubyable (V.Vector a) where
+  toRuby = RArray . V.map toRuby
+  fromRuby = \case
+    RArray x -> V.mapM fromRuby x
+    _        -> Nothing
+
+instance (Rubyable a, Rubyable b) => Rubyable (V.Vector (a, b)) where
+  toRuby x = RHash $ V.map (toRuby *** toRuby) x
+  fromRuby = \case
+    RHash x -> V.mapM (\(k, v) -> (,) <$> fromRuby k <*> fromRuby v) x
+    _       -> Nothing
+
+instance Rubyable BS.ByteString where
+  toRuby = RSymbol
+  fromRuby = \case
+    RSymbol x -> Just x
+    _         -> Nothing
+
+instance Rubyable Float where
+  toRuby = RFloat
+  fromRuby = \case
+    RFloat  x -> Just x
+    _         -> Nothing
+
+instance Rubyable (BS.ByteString, REncoding) where
+  toRuby (x, y) = RIVar (RString x, y)
+  fromRuby = \case
+    RIVar (RString x, y) -> Just (x, y)
+    _                    -> Nothing
+
+-- nil like
+
+instance Rubyable a => Rubyable (Maybe a) where
+  toRuby = \case
+    Just x  -> toRuby x
+    Nothing -> RNil
+
+  fromRuby = \case
+    RNil -> Just Nothing
+    x    -> fromRuby x
+
+-- array like
+
+instance Rubyable a => Rubyable [a] where
+  toRuby = toRuby . V.fromList
+  fromRuby x = V.toList <$> fromRuby x
+
+-- map like
+
+instance (Rubyable a, Rubyable b) => Rubyable [(a, b)] where
+  toRuby = toRuby . V.fromList
+  fromRuby x = V.toList <$> fromRuby x
+
+instance (Rubyable a, Rubyable b, Ord a) => Rubyable (DM.Map a b) where
+  toRuby = toRuby . DM.toList
+  fromRuby x = DM.fromList <$> fromRuby x

--- a/src/Data/Ruby/Marshal/RubyObject.hs
+++ b/src/Data/Ruby/Marshal/RubyObject.hs
@@ -16,11 +16,7 @@
 --
 --------------------------------------------------------------------
 
-module Data.Ruby.Marshal.RubyObject (
-    IVar
-  , REncoding(..)
-  , RubyObject(..)
-) where
+module Data.Ruby.Marshal.RubyObject where
 
 import Control.Applicative
 import Prelude
@@ -55,9 +51,6 @@ data RubyObject
   | Unsupported
     -- ^ represents an invalid object
   deriving (Eq, Ord, Show)
-
--- | Handy type alias for IVars.
-type IVar = (BS.ByteString, REncoding)
 
 -- | Transform plain Haskell values to RubyObjects and back.
 class Ruby a where

--- a/src/Data/Ruby/Marshal/RubyObject.hs
+++ b/src/Data/Ruby/Marshal/RubyObject.hs
@@ -31,8 +31,6 @@ import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as DM
 import qualified Data.Vector     as V
 
-type IVar = (BS.ByteString, REncoding)
-
 -- | Representation of a Ruby object.
 data RubyObject
   = RNil
@@ -56,6 +54,9 @@ data RubyObject
   | RError                 !Error
     -- ^ represents an invalid object
   deriving (Eq, Ord, Show)
+
+-- | Handy type alias for IVars.
+type IVar = (BS.ByteString, REncoding)
 
 -- | Convey when unsupported object encountered.
 data Error

--- a/src/Data/Ruby/Marshal/RubyObject.hs
+++ b/src/Data/Ruby/Marshal/RubyObject.hs
@@ -22,7 +22,7 @@ import Control.Applicative
 import Prelude
 
 import Control.Arrow              ((***))
-import Data.Ruby.Marshal.Encoding (REncoding(..))
+import Data.Ruby.Marshal.Encoding (RubyStringEncoding(..))
 
 import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as DM
@@ -40,7 +40,7 @@ data RubyObject
     -- ^ represents an @Array@
   | RHash                  !(V.Vector (RubyObject, RubyObject))
     -- ^ represents an @Hash@
-  | RIVar                  !(RubyObject, REncoding)
+  | RIVar                  !(RubyObject, RubyStringEncoding)
     -- ^ represents an @IVar@
   | RString                !BS.ByteString
     -- ^ represents a @String@
@@ -107,7 +107,7 @@ instance Ruby Float where
     RFloat  x -> Just x
     _         -> Nothing
 
-instance Ruby (BS.ByteString, REncoding) where
+instance Ruby (BS.ByteString, RubyStringEncoding) where
   toRuby (x, y) = RIVar (RString x, y)
   fromRuby = \case
     RIVar (RString x, y) -> Just (x, y)

--- a/src/Data/Ruby/Marshal/RubyObject.hs
+++ b/src/Data/Ruby/Marshal/RubyObject.hs
@@ -31,6 +31,8 @@ import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as DM
 import qualified Data.Vector     as V
 
+type IVar = (BS.ByteString, REncoding)
+
 -- | Representation of a Ruby object.
 data RubyObject
   = RNil

--- a/src/Data/Ruby/Marshal/RubyObject.hs
+++ b/src/Data/Ruby/Marshal/RubyObject.hs
@@ -65,7 +65,7 @@ data Error
   deriving (Eq, Ord, Show)
 
 -- | Transform plain Haskell values to RubyObjects and back.
-class Rubyable a where
+class Ruby a where
   -- | Takes a plain Haskell value and lifts into RubyObject
   toRuby :: a -> RubyObject
   -- | Takes a RubyObject transforms it into a more general Haskell value.
@@ -73,53 +73,53 @@ class Rubyable a where
 
 -- core instances
 
-instance Rubyable RubyObject where
+instance Ruby RubyObject where
   toRuby = id
   fromRuby = Just
 
-instance Rubyable () where
+instance Ruby () where
   toRuby _ = RNil
   fromRuby = \case
     RNil -> Just ()
     _    -> Nothing
 
-instance Rubyable Bool where
+instance Ruby Bool where
   toRuby = RBool
   fromRuby = \case
     RBool x -> Just x
     _       -> Nothing
 
-instance Rubyable Int where
+instance Ruby Int where
   toRuby = RFixnum
   fromRuby = \case
     RFixnum x -> Just x
     _         -> Nothing
 
-instance Rubyable a => Rubyable (V.Vector a) where
+instance Ruby a => Ruby (V.Vector a) where
   toRuby = RArray . V.map toRuby
   fromRuby = \case
     RArray x -> V.mapM fromRuby x
     _        -> Nothing
 
-instance (Rubyable a, Rubyable b) => Rubyable (V.Vector (a, b)) where
+instance (Ruby a, Ruby b) => Ruby (V.Vector (a, b)) where
   toRuby x = RHash $ V.map (toRuby *** toRuby) x
   fromRuby = \case
     RHash x -> V.mapM (\(k, v) -> (,) <$> fromRuby k <*> fromRuby v) x
     _       -> Nothing
 
-instance Rubyable BS.ByteString where
+instance Ruby BS.ByteString where
   toRuby = RSymbol
   fromRuby = \case
     RSymbol x -> Just x
     _         -> Nothing
 
-instance Rubyable Float where
+instance Ruby Float where
   toRuby = RFloat
   fromRuby = \case
     RFloat  x -> Just x
     _         -> Nothing
 
-instance Rubyable (BS.ByteString, REncoding) where
+instance Ruby (BS.ByteString, REncoding) where
   toRuby (x, y) = RIVar (RString x, y)
   fromRuby = \case
     RIVar (RString x, y) -> Just (x, y)
@@ -127,7 +127,7 @@ instance Rubyable (BS.ByteString, REncoding) where
 
 -- nil like
 
-instance Rubyable a => Rubyable (Maybe a) where
+instance Ruby a => Ruby (Maybe a) where
   toRuby = \case
     Just x  -> toRuby x
     Nothing -> RNil
@@ -138,16 +138,16 @@ instance Rubyable a => Rubyable (Maybe a) where
 
 -- array like
 
-instance Rubyable a => Rubyable [a] where
+instance Ruby a => Ruby [a] where
   toRuby = toRuby . V.fromList
   fromRuby x = V.toList <$> fromRuby x
 
 -- map like
 
-instance (Rubyable a, Rubyable b) => Rubyable [(a, b)] where
+instance (Ruby a, Ruby b) => Ruby [(a, b)] where
   toRuby = toRuby . V.fromList
   fromRuby x = V.toList <$> fromRuby x
 
-instance (Rubyable a, Rubyable b, Ord a) => Rubyable (DM.Map a b) where
+instance (Ruby a, Ruby b, Ord a) => Ruby (DM.Map a b) where
   toRuby = toRuby . DM.toList
   fromRuby x = DM.fromList <$> fromRuby x

--- a/src/Data/Ruby/Marshal/RubyObject.hs
+++ b/src/Data/Ruby/Marshal/RubyObject.hs
@@ -53,7 +53,7 @@ data RubyObject
   deriving (Eq, Ord, Show)
 
 -- | Transform plain Haskell values to RubyObjects and back.
-class Ruby a where
+class Rubyable a where
   -- | Takes a plain Haskell value and lifts into RubyObject
   toRuby :: a -> RubyObject
   -- | Takes a RubyObject transforms it into a more general Haskell value.
@@ -61,53 +61,53 @@ class Ruby a where
 
 -- core instances
 
-instance Ruby RubyObject where
+instance Rubyable RubyObject where
   toRuby = id
   fromRuby = Just
 
-instance Ruby () where
+instance Rubyable () where
   toRuby _ = RNil
   fromRuby = \case
     RNil -> Just ()
     _    -> Nothing
 
-instance Ruby Bool where
+instance Rubyable Bool where
   toRuby = RBool
   fromRuby = \case
     RBool x -> Just x
     _       -> Nothing
 
-instance Ruby Int where
+instance Rubyable Int where
   toRuby = RFixnum
   fromRuby = \case
     RFixnum x -> Just x
     _         -> Nothing
 
-instance Ruby a => Ruby (V.Vector a) where
+instance Rubyable a => Rubyable (V.Vector a) where
   toRuby = RArray . V.map toRuby
   fromRuby = \case
     RArray x -> V.mapM fromRuby x
     _        -> Nothing
 
-instance (Ruby a, Ruby b) => Ruby (V.Vector (a, b)) where
+instance (Rubyable a, Rubyable b) => Rubyable (V.Vector (a, b)) where
   toRuby x = RHash $ V.map (toRuby *** toRuby) x
   fromRuby = \case
     RHash x -> V.mapM (\(k, v) -> (,) <$> fromRuby k <*> fromRuby v) x
     _       -> Nothing
 
-instance Ruby BS.ByteString where
+instance Rubyable BS.ByteString where
   toRuby = RSymbol
   fromRuby = \case
     RSymbol x -> Just x
     _         -> Nothing
 
-instance Ruby Float where
+instance Rubyable Float where
   toRuby = RFloat
   fromRuby = \case
     RFloat  x -> Just x
     _         -> Nothing
 
-instance Ruby (BS.ByteString, RubyStringEncoding) where
+instance Rubyable (BS.ByteString, RubyStringEncoding) where
   toRuby (x, y) = RIVar (RString x, y)
   fromRuby = \case
     RIVar (RString x, y) -> Just (x, y)
@@ -115,7 +115,7 @@ instance Ruby (BS.ByteString, RubyStringEncoding) where
 
 -- nil like
 
-instance Ruby a => Ruby (Maybe a) where
+instance Rubyable a => Rubyable (Maybe a) where
   toRuby = \case
     Just x  -> toRuby x
     Nothing -> RNil
@@ -126,16 +126,16 @@ instance Ruby a => Ruby (Maybe a) where
 
 -- array like
 
-instance Ruby a => Ruby [a] where
+instance Rubyable a => Rubyable [a] where
   toRuby = toRuby . V.fromList
   fromRuby x = V.toList <$> fromRuby x
 
 -- map like
 
-instance (Ruby a, Ruby b) => Ruby [(a, b)] where
+instance (Rubyable a, Rubyable b) => Rubyable [(a, b)] where
   toRuby = toRuby . V.fromList
   fromRuby x = V.toList <$> fromRuby x
 
-instance (Ruby a, Ruby b, Ord a) => Ruby (DM.Map a b) where
+instance (Rubyable a, Rubyable b, Ord a) => Rubyable (DM.Map a b) where
   toRuby = toRuby . DM.toList
   fromRuby x = DM.fromList <$> fromRuby x

--- a/src/Data/Ruby/Marshal/Types.hs
+++ b/src/Data/Ruby/Marshal/Types.hs
@@ -165,6 +165,23 @@ instance Rubyable (BS.ByteString, REncoding) where
     RIVar (RString x, y) -> Just (x, y)
     _                    -> Nothing
 
+-- nil like
+
+instance Rubyable a => Rubyable (Maybe a) where
+  toRuby = \case
+    Just x  -> toRuby x
+    Nothing -> RNil
+
+  fromRuby = \case
+    RNil -> Just Nothing
+    x    -> fromRuby x
+
+-- array like
+
+instance Rubyable a => Rubyable [a] where
+  toRuby = toRuby . V.fromList
+  fromRuby x = V.toList <$> fromRuby x
+
 -- map like
 
 instance (Rubyable a, Rubyable b) => Rubyable [(a, b)] where

--- a/src/Data/Ruby/Marshal/Types.hs
+++ b/src/Data/Ruby/Marshal/Types.hs
@@ -150,6 +150,13 @@ instance Rubyable BS.ByteString where
   toRuby = RString
   fromRuby = \case
     RString x -> Just x
+    RSymbol x -> Just x
+    _         -> Nothing
+
+instance Rubyable Float where
+  toRuby = RFloat
+  fromRuby = \case
+    RFloat  x -> Just x
     _         -> Nothing
 
 -- map like

--- a/src/Data/Ruby/Marshal/Types.hs
+++ b/src/Data/Ruby/Marshal/Types.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE PatternSynonyms #-}
 
 --------------------------------------------------------------------
@@ -18,70 +17,49 @@
 module Data.Ruby.Marshal.Types (
   -- * Marshal Monad
     Marshal
+  -- * Internal cache
+  , Cache
   -- * Patterns
-  , pattern NilC
-  , pattern FalseC
-  , pattern TrueC
-  , pattern ArrayC
-  , pattern FixnumC
-  , pattern FloatC
-  , pattern HashC
-  , pattern IVarC
-  , pattern ObjectLinkC
-  , pattern StringC
-  , pattern SymbolC
-  , pattern SymlinkC
+  , pattern NilChar
+  , pattern FalseChar
+  , pattern TrueChar
+  , pattern ArrayChar
+  , pattern FixnumChar
+  , pattern FloatChar
+  , pattern HashChar
+  , pattern IVarChar
+  , pattern ObjectLinkChar
+  , pattern StringChar
+  , pattern SymbolChar
+  , pattern SymlinkChar
   -- * Re-exported modules
   , module Data.Ruby.Marshal.RubyObject
 ) where
 
-import Control.Applicative
 import Data.Ruby.Marshal.RubyObject
-import Prelude
+import Data.Ruby.Marshal.Monad (Cache, Marshal)
 
-import Control.Monad.State (lift, MonadState, StateT)
-import Data.Serialize.Get  (Get)
-
-import qualified Data.Vector as V
-
--- | Marshal monad endows the underlying Get monad with State.
-newtype Marshal a = Marshal {
-  runMarshal :: StateT Cache Get a
-} deriving (Functor, Applicative, Monad, MonadState Cache)
-
--- | Lift Get monad into Marshal monad.
-liftMarshal :: Get a -> Marshal a
-liftMarshal = Marshal . lift
-
--- | State that we must carry around during parsing.
-data Cache = Cache {
-    _objects :: !(V.Vector RubyObject)
-    -- ^ object cache.
-  , _symbols :: !(V.Vector RubyObject)
-    -- ^ symbol cache.
-} deriving Show
-
--- | Character that represents NilClass.
-pattern NilC = 48
+-- | Character that represents NilCharlass.
+pattern NilChar = 48
 -- | Character that represents FalseClass.
-pattern FalseC = 70
+pattern FalseChar = 70
 -- | Character that represents TrueClass.
-pattern TrueC = 84
+pattern TrueChar = 84
 -- | Character that represents Array.
-pattern ArrayC = 91
+pattern ArrayChar = 91
 -- | Character that represents Fixnum.
-pattern FixnumC = 105
+pattern FixnumChar = 105
 -- | Character that represents Float.
-pattern FloatC = 102
+pattern FloatChar = 102
 -- | Character that represents Hash.
-pattern HashC = 123
+pattern HashChar = 123
 -- | Character that represents IVar.
-pattern IVarC = 73
+pattern IVarChar = 73
 -- | Character that represents Object link.
-pattern ObjectLinkC = 64
+pattern ObjectLinkChar = 64
 -- | Character that represents String.
-pattern StringC = 34
+pattern StringChar = 34
 -- | Character that represents Symbol.
-pattern SymbolC = 58
+pattern SymbolChar = 58
 -- | Character that represents Symlink.
-pattern SymlinkC = 59
+pattern SymlinkChar = 59

--- a/src/Data/Ruby/Marshal/Types.hs
+++ b/src/Data/Ruby/Marshal/Types.hs
@@ -16,6 +16,7 @@
 --------------------------------------------------------------------
 
 module Data.Ruby.Marshal.Types (
+    -- * Re-exported modules
     module Data.Ruby.Marshal.RubyObject
   , module Data.Ruby.Marshal.Types
 ) where

--- a/src/Data/Ruby/Marshal/Types.hs
+++ b/src/Data/Ruby/Marshal/Types.hs
@@ -1,7 +1,4 @@
-{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE IncoherentInstances #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE PatternSynonyms #-}
 
 --------------------------------------------------------------------

--- a/src/Data/Ruby/Marshal/Types.hs
+++ b/src/Data/Ruby/Marshal/Types.hs
@@ -23,9 +23,10 @@ module Data.Ruby.Marshal.Types where
 import Control.Applicative
 import Prelude
 
-import Control.Arrow       ((***))
-import Control.Monad.State (lift, MonadState, StateT)
-import Data.Serialize.Get  (Get)
+import Control.Arrow              ((***))
+import Control.Monad.State        (lift, MonadState, StateT)
+import Data.Ruby.Marshal.Encoding (REncoding(..))
+import Data.Serialize.Get         (Get)
 
 import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as DM
@@ -85,7 +86,7 @@ data RubyObject
     -- ^ represents an @Array@
   | RHash                  !(V.Vector (RubyObject, RubyObject))
     -- ^ represents an @Hash@
-  | RIVar                  !(RubyObject, BS.ByteString)
+  | RIVar                  !(RubyObject, REncoding)
     -- ^ represents an @IVar@
   | RString                !BS.ByteString
     -- ^ represents a @String@
@@ -101,7 +102,7 @@ data RubyObject
 data Error
   = Unsupported
     -- ^ represents an unsupported Ruby object
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Show)
 
 -- | Transform plain Haskell values to RubyObjects and back.
 class Rubyable a where

--- a/src/Data/Ruby/Marshal/Types.hs
+++ b/src/Data/Ruby/Marshal/Types.hs
@@ -96,13 +96,13 @@ data RubyObject
     -- ^ represents a @Symbol@
   | RError                 !Error
     -- ^ represents an invalid object
-  deriving (Eq, Show)
+  deriving (Eq, Ord, Show)
 
 -- | Convey when unsupported object encountered.
 data Error
   = Unsupported
     -- ^ represents an unsupported Ruby object
-  deriving (Eq, Show)
+  deriving (Eq, Ord, Show)
 
 -- | Transform plain Haskell values to RubyObjects and back.
 class Rubyable a where

--- a/src/Data/Ruby/Marshal/Types.hs
+++ b/src/Data/Ruby/Marshal/Types.hs
@@ -32,6 +32,23 @@ import Data.Serialize.Get         (Get)
 
 import qualified Data.Vector     as V
 
+-- | Marshal monad endows the underlying Get monad with State.
+newtype Marshal a = Marshal {
+  runMarshal :: StateT Cache Get a
+} deriving (Functor, Applicative, Monad, MonadState Cache)
+
+-- | Lift Get monad into Marshal monad.
+liftMarshal :: Get a -> Marshal a
+liftMarshal = Marshal . lift
+
+-- | State that we must carry around during parsing.
+data Cache = Cache {
+    _objects :: !(V.Vector RubyObject)
+    -- ^ object cache.
+  , _symbols :: !(V.Vector RubyObject)
+    -- ^ symbol cache.
+} deriving Show
+
 -- | Character that represents NilClass.
 pattern NilC = 48
 -- | Character that represents FalseClass.
@@ -56,20 +73,3 @@ pattern StringC = 34
 pattern SymbolC = 58
 -- | Character that represents Symlink.
 pattern SymlinkC = 59
-
--- | State that we must carry around during parsing.
-data Cache = Cache {
-    _objects :: !(V.Vector RubyObject)
-    -- ^ object cache.
-  , _symbols :: !(V.Vector RubyObject)
-    -- ^ symbol cache.
-  } deriving Show
-
--- | Marshal monad endows the underlying Get monad with State.
-newtype Marshal a = Marshal {
-  runMarshal :: StateT Cache Get a
-} deriving (Functor, Applicative, Monad, MonadState Cache)
-
--- | Lift Get monad into Marshal monad.
-liftMarshal :: Get a -> Marshal a
-liftMarshal = Marshal . lift

--- a/src/Data/Ruby/Marshal/Types.hs
+++ b/src/Data/Ruby/Marshal/Types.hs
@@ -89,7 +89,7 @@ data RubyObject
     -- ^ represents an @IVar@
   | RString                !BS.ByteString
     -- ^ represents a @String@
-  | RFloat {-# UNPACK #-}  !Double
+  | RFloat {-# UNPACK #-}  !Float
     -- ^ represents a @Float@
   | RSymbol                !BS.ByteString
     -- ^ represents a @Symbol@
@@ -145,6 +145,12 @@ instance (Rubyable a, Rubyable b) => Rubyable (V.Vector (a, b)) where
   fromRuby = \case
     RHash x -> V.mapM (\(k, v) -> (,) <$> fromRuby k <*> fromRuby v) x
     _       -> Nothing
+
+instance Rubyable BS.ByteString where
+  toRuby = RString
+  fromRuby = \case
+    RString x -> Just x
+    _         -> Nothing
 
 -- map like
 

--- a/src/Data/Ruby/Marshal/Types.hs
+++ b/src/Data/Ruby/Marshal/Types.hs
@@ -19,6 +19,10 @@ module Data.Ruby.Marshal.Types (
     Marshal
   -- * Internal cache
   , Cache
+  -- * Ruby string encodings
+  , REncoding(..)
+  -- * Ruby object
+  , RubyObject(..)
   -- * Patterns
   , pattern NilChar
   , pattern FalseChar
@@ -32,12 +36,11 @@ module Data.Ruby.Marshal.Types (
   , pattern StringChar
   , pattern SymbolChar
   , pattern SymlinkChar
-  -- * Re-exported modules
-  , module Data.Ruby.Marshal.RubyObject
 ) where
 
+import Data.Ruby.Marshal.Encoding
+import Data.Ruby.Marshal.Monad
 import Data.Ruby.Marshal.RubyObject
-import Data.Ruby.Marshal.Monad (Cache, Marshal)
 
 -- | Character that represents NilCharlass.
 pattern NilChar = 48

--- a/src/Data/Ruby/Marshal/Types.hs
+++ b/src/Data/Ruby/Marshal/Types.hs
@@ -27,10 +27,10 @@ import Control.Applicative
 import Data.Ruby.Marshal.RubyObject
 import Prelude
 
-import Control.Monad.State        (lift, MonadState, StateT)
-import Data.Serialize.Get         (Get)
+import Control.Monad.State (lift, MonadState, StateT)
+import Data.Serialize.Get  (Get)
 
-import qualified Data.Vector     as V
+import qualified Data.Vector as V
 
 -- | Marshal monad endows the underlying Get monad with State.
 newtype Marshal a = Marshal {

--- a/src/Data/Ruby/Marshal/Types.hs
+++ b/src/Data/Ruby/Marshal/Types.hs
@@ -147,9 +147,8 @@ instance (Rubyable a, Rubyable b) => Rubyable (V.Vector (a, b)) where
     _       -> Nothing
 
 instance Rubyable BS.ByteString where
-  toRuby = RString
+  toRuby = RSymbol
   fromRuby = \case
-    RString x -> Just x
     RSymbol x -> Just x
     _         -> Nothing
 

--- a/src/Data/Ruby/Marshal/Types.hs
+++ b/src/Data/Ruby/Marshal/Types.hs
@@ -21,11 +21,11 @@
 module Data.Ruby.Marshal.Types where
 
 import Control.Applicative
+import Data.Ruby.Marshal.Encoding
 import Prelude
 
 import Control.Arrow              ((***))
 import Control.Monad.State        (lift, MonadState, StateT)
-import Data.Ruby.Marshal.Encoding (REncoding(..))
 import Data.Serialize.Get         (Get)
 
 import qualified Data.ByteString as BS
@@ -158,6 +158,12 @@ instance Rubyable Float where
   fromRuby = \case
     RFloat  x -> Just x
     _         -> Nothing
+
+instance Rubyable (BS.ByteString, REncoding) where
+  toRuby (x, y) = RIVar (RString x, y)
+  fromRuby = \case
+    RIVar (RString x, y) -> Just (x, y)
+    _                    -> Nothing
 
 -- map like
 

--- a/src/Data/Ruby/Marshal/Types.hs
+++ b/src/Data/Ruby/Marshal/Types.hs
@@ -16,9 +16,23 @@
 --------------------------------------------------------------------
 
 module Data.Ruby.Marshal.Types (
-    -- * Re-exported modules
-    module Data.Ruby.Marshal.RubyObject
-  , module Data.Ruby.Marshal.Types
+  -- * Marshal Monad
+    Marshal
+  -- * Patterns
+  , pattern NilC
+  , pattern FalseC
+  , pattern TrueC
+  , pattern ArrayC
+  , pattern FixnumC
+  , pattern FloatC
+  , pattern HashC
+  , pattern IVarC
+  , pattern ObjectLinkC
+  , pattern StringC
+  , pattern SymbolC
+  , pattern SymlinkC
+  -- * Re-exported modules
+  , module Data.Ruby.Marshal.RubyObject
 ) where
 
 import Control.Applicative

--- a/src/Data/Ruby/Marshal/Types.hs
+++ b/src/Data/Ruby/Marshal/Types.hs
@@ -18,18 +18,18 @@
 --
 --------------------------------------------------------------------
 
-module Data.Ruby.Marshal.Types where
+module Data.Ruby.Marshal.Types (
+    module Data.Ruby.Marshal.RubyObject
+  , module Data.Ruby.Marshal.Types
+) where
 
 import Control.Applicative
-import Data.Ruby.Marshal.Encoding
+import Data.Ruby.Marshal.RubyObject
 import Prelude
 
-import Control.Arrow              ((***))
 import Control.Monad.State        (lift, MonadState, StateT)
 import Data.Serialize.Get         (Get)
 
-import qualified Data.ByteString as BS
-import qualified Data.Map.Strict as DM
 import qualified Data.Vector     as V
 
 -- | Character that represents NilClass.
@@ -68,126 +68,8 @@ data Cache = Cache {
 -- | Marshal monad endows the underlying Get monad with State.
 newtype Marshal a = Marshal {
   runMarshal :: StateT Cache Get a
-  } deriving (Functor, Applicative, Monad, MonadState Cache)
+} deriving (Functor, Applicative, Monad, MonadState Cache)
 
 -- | Lift Get monad into Marshal monad.
 liftMarshal :: Get a -> Marshal a
 liftMarshal = Marshal . lift
-
--- | Representation of a Ruby object.
-data RubyObject
-  = RNil
-    -- ^ represents @nil@
-  | RBool                  !Bool
-    -- ^ represents @true@ or @false@
-  | RFixnum {-# UNPACK #-} !Int
-    -- ^ represents a @Fixnum@
-  | RArray                 !(V.Vector RubyObject)
-    -- ^ represents an @Array@
-  | RHash                  !(V.Vector (RubyObject, RubyObject))
-    -- ^ represents an @Hash@
-  | RIVar                  !(RubyObject, REncoding)
-    -- ^ represents an @IVar@
-  | RString                !BS.ByteString
-    -- ^ represents a @String@
-  | RFloat {-# UNPACK #-}  !Float
-    -- ^ represents a @Float@
-  | RSymbol                !BS.ByteString
-    -- ^ represents a @Symbol@
-  | RError                 !Error
-    -- ^ represents an invalid object
-  deriving (Eq, Ord, Show)
-
--- | Convey when unsupported object encountered.
-data Error
-  = Unsupported
-    -- ^ represents an unsupported Ruby object
-  deriving (Eq, Ord, Show)
-
--- | Transform plain Haskell values to RubyObjects and back.
-class Rubyable a where
-  -- | Takes a plain Haskell value and lifts into RubyObject
-  toRuby :: a -> RubyObject
-  -- | Takes a RubyObject transforms it into a more general Haskell value.
-  fromRuby :: RubyObject -> Maybe a
-
--- core instances
-
-instance Rubyable RubyObject where
-  toRuby = id
-  fromRuby = Just
-
-instance Rubyable () where
-  toRuby _ = RNil
-  fromRuby = \case
-    RNil -> Just ()
-    _    -> Nothing
-
-instance Rubyable Bool where
-  toRuby = RBool
-  fromRuby = \case
-    RBool x -> Just x
-    _       -> Nothing
-
-instance Rubyable Int where
-  toRuby = RFixnum
-  fromRuby = \case
-    RFixnum x -> Just x
-    _         -> Nothing
-
-instance Rubyable a => Rubyable (V.Vector a) where
-  toRuby = RArray . V.map toRuby
-  fromRuby = \case
-    RArray x -> V.mapM fromRuby x
-    _        -> Nothing
-
-instance (Rubyable a, Rubyable b) => Rubyable (V.Vector (a, b)) where
-  toRuby x = RHash $ V.map (toRuby *** toRuby) x
-  fromRuby = \case
-    RHash x -> V.mapM (\(k, v) -> (,) <$> fromRuby k <*> fromRuby v) x
-    _       -> Nothing
-
-instance Rubyable BS.ByteString where
-  toRuby = RSymbol
-  fromRuby = \case
-    RSymbol x -> Just x
-    _         -> Nothing
-
-instance Rubyable Float where
-  toRuby = RFloat
-  fromRuby = \case
-    RFloat  x -> Just x
-    _         -> Nothing
-
-instance Rubyable (BS.ByteString, REncoding) where
-  toRuby (x, y) = RIVar (RString x, y)
-  fromRuby = \case
-    RIVar (RString x, y) -> Just (x, y)
-    _                    -> Nothing
-
--- nil like
-
-instance Rubyable a => Rubyable (Maybe a) where
-  toRuby = \case
-    Just x  -> toRuby x
-    Nothing -> RNil
-
-  fromRuby = \case
-    RNil -> Just Nothing
-    x    -> fromRuby x
-
--- array like
-
-instance Rubyable a => Rubyable [a] where
-  toRuby = toRuby . V.fromList
-  fromRuby x = V.toList <$> fromRuby x
-
--- map like
-
-instance (Rubyable a, Rubyable b) => Rubyable [(a, b)] where
-  toRuby = toRuby . V.fromList
-  fromRuby x = V.toList <$> fromRuby x
-
-instance (Rubyable a, Rubyable b, Ord a) => Rubyable (DM.Map a b) where
-  toRuby = toRuby . DM.toList
-  fromRuby x = DM.fromList <$> fromRuby x

--- a/src/Data/Ruby/Marshal/Types.hs
+++ b/src/Data/Ruby/Marshal/Types.hs
@@ -20,7 +20,7 @@ module Data.Ruby.Marshal.Types (
   -- * Internal cache
   , Cache
   -- * Ruby string encodings
-  , REncoding(..)
+  , RubyStringEncoding(..)
   -- * Ruby object
   , RubyObject(..)
   -- * Patterns

--- a/test/MarshalSpec.hs
+++ b/test/MarshalSpec.hs
@@ -6,7 +6,6 @@ import Data.Ruby.Marshal
 import Test.Hspec
 
 import qualified Data.ByteString as BS
-import qualified Data.Map.Strict as DM
 import qualified Data.Vector     as V
 
 loadBin :: FilePath -> IO (Maybe RubyObject)
@@ -84,7 +83,7 @@ spec = describe "load" $ do
   context "when we have { 0 => false, 1 => true }" $
     it "should parse" $ do
       object <- loadBin "test/bin/fixnumHash.bin"
-      object `shouldBe` Just (RHash $ DM.fromList [(RFixnum 0, RBool False), (RFixnum 1, RBool True)])
+      object `shouldBe` Just (RHash $ V.fromList [(RFixnum 0, RBool False), (RFixnum 1, RBool True)])
 
   context "when we have 'hello haskell'" $
     it "should parse" $ do

--- a/test/MarshalSpec.hs
+++ b/test/MarshalSpec.hs
@@ -3,7 +3,6 @@
 module MarshalSpec (spec) where
 
 import Data.Ruby.Marshal
-import Data.Ruby.Marshal.Encoding (REncoding(..))
 import Test.Hspec
 
 import qualified Data.ByteString as BS

--- a/test/MarshalSpec.hs
+++ b/test/MarshalSpec.hs
@@ -3,6 +3,7 @@
 module MarshalSpec (spec) where
 
 import Data.Ruby.Marshal
+import Data.Ruby.Marshal.Encoding (REncoding(..))
 import Test.Hspec
 
 import qualified Data.ByteString as BS
@@ -73,7 +74,7 @@ spec = describe "load" $ do
   context "when we have ['hello', 'haskell', 'hello', 'haskell']" $
     it "should parse" $ do
       object <- loadBin "test/bin/stringArray.bin"
-      object `shouldBe` Just (RArray $ V.fromList [RIVar (RString "hello", "UTF-8"), RIVar (RString "haskell", "UTF-8"), RIVar (RString "hello", "UTF-8"), RIVar (RString "haskell", "UTF-8")])
+      object `shouldBe` Just (RArray $ V.fromList [RIVar (RString "hello", UTF_8), RIVar (RString "haskell", UTF_8), RIVar (RString "hello", UTF_8), RIVar (RString "haskell", UTF_8)])
 
   context "when we have [:hello, :haskell, :hello, :haskell]" $
     it "should parse" $ do
@@ -88,17 +89,17 @@ spec = describe "load" $ do
   context "when we have 'hello haskell'" $
     it "should parse" $ do
       object <- loadBin "test/bin/UTF_8_String.bin"
-      object `shouldBe` Just (RIVar (RString "hello haskell", "UTF-8"))
+      object `shouldBe` Just (RIVar (RString "hello haskell", UTF_8))
 
   context "when we have 'hello haskell' in US-ASCII" $
     it "should parse" $ do
       object <- loadBin "test/bin/US_ASCII_String.bin"
-      object `shouldBe` Just (RIVar (RString "hello haskell", "US-ASCII"))
+      object `shouldBe` Just (RIVar (RString "hello haskell", US_ASCII))
 
   context "when we have 'hello haskell' in SHIFT_JIS" $
     it "should parse" $ do
       object <- loadBin "test/bin/Shift_JIS_String.bin"
-      object `shouldBe` Just (RIVar (RString "hello haskell", "Shift_JIS"))
+      object `shouldBe` Just (RIVar (RString "hello haskell", Shift_JIS))
 
   context "when we have 3.33333" $
     it "should parse" $ do


### PR DESCRIPTION
I'm not entirely satisfied with this PR and I'm a bit annoyed that I let myself get carried away. Here's what this brings to the table.

- Adds more type safety for string encodings by using an ADT containing all Ruby string encodings.
- Adds `Rubyable` class to more easily go between `RubyObject` and plain Haskell values.
- Changes `RFloat` to use `Float` instead of `Double`.
- Replaced internal representation of parser to use vector of tuples for Hashes for sake of simplicity.
- Hid as much of the underlying Get monad as possible from consumers.
- Shuffled around the modules a bit. 
- Added changelog.
- Fixed bug in parse fail labelling.
- Bumped version.
<hr/>
Closes #46 