### PR TITLE
Ghc8.0.2 resolver bounds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ cabal.sandbox.config
 *.aux
 *.hp
 *.ps
+.stack-work/
+*~
+stack.yaml
 
 # ruby
 .ruby-version

--- a/ruby-marshal.cabal
+++ b/ruby-marshal.cabal
@@ -29,12 +29,12 @@ library
     src
   build-depends:
       base        >= 4.7    && <= 5
-    , cereal      >= 0.4.0  && <= 0.5.0
+    , cereal      >= 0.4.0  && <  0.5.5
     , bytestring  >= 0.9.0  && <= 0.12.0
     , containers  >= 0.5.0  && <= 0.6.0
     , string-conv >= 0.1    && <= 0.2
     , mtl         >= 2.1.0  && <= 2.3.0
-    , vector      >= 0.10.0 && <= 0.11.0
+    , vector      >= 0.10.0 && <  0.12.1
   default-language:
     Haskell2010
   exposed-modules:

--- a/stack-ghc-8.0.2.yaml
+++ b/stack-ghc-8.0.2.yaml
@@ -1,5 +1,0 @@
-resolver: nightly-2017-03-30
-extra-deps:
-- vector-0.10.12.3
-- cereal-0.4.1.1
-- primitive-0.6.1.0

--- a/stack-ghc-8.0.2.yaml
+++ b/stack-ghc-8.0.2.yaml
@@ -1,0 +1,5 @@
+resolver: nightly-2017-03-30
+extra-deps:
+- vector-0.10.12.3
+- cereal-0.4.1.1
+- primitive-0.6.1.0


### PR DESCRIPTION
I am not an expert in how to specify version bounds, but this worked and tests passed with:

```
> stack init --force --resolver nightly && stack --install-ghc build --test
...
Selected resolver: nightly-2017-03-30
...
19 examples, 0 failures
```

Closes https://github.com/filib/ruby-marshal/issues/55. Please publish to hackage if you merge.