### PR TITLE
Update packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # haskell
 dist
+dist-newstyle
 cabal-dev
 *.o
 *.hi

--- a/ruby-marshal.cabal
+++ b/ruby-marshal.cabal
@@ -29,9 +29,9 @@ library
     , cereal      >= 0.4.0   && <  0.6.0
     , containers  >= 0.5.0   && <= 0.7.0
     , fail        >= 4.9.0.0 && < 4.10
-    , string-conv >= 0.1     && <= 0.2
+    , string-conv >= 0.1     && < 0.3
     , mtl         >= 2.1.0   && <= 2.3.0
-    , vector      >= 0.10.0  && <  0.13
+    , vector      >= 0.10.0  && <  0.14
   default-language:
     Haskell2010
   exposed-modules:


### PR DESCRIPTION
Tested using `cabal test --constraint 'vector == 0.13.0.0' --constraint 'string-conv == 0.2.0'`

This should only require a metadata revision on Hackage